### PR TITLE
Ensure list items used as nav-items do not have a bullet points.

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -285,6 +285,10 @@ nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
   background-color: #61ae24 !important;
 }
 
+nav li.nav-item {
+  list-style-type: none;
+}
+
 nav .navbar-nav li a {
   color: #cdcdcd !important;
 }


### PR DESCRIPTION
Ensure list items used as nav-items do not have a bullet point. Fixes bullet point shown beside the `Sign In` button on smaller screens.