### PR TITLE
Remove some element selectors as they aren't good practice

### DIFF
--- a/components/OutcomeModal.vue
+++ b/components/OutcomeModal.vue
@@ -14,7 +14,7 @@
       </b-row>
       <b-row>
         <b-col>
-          <b-select v-model="type" @change="changeType">
+          <b-select v-model="type" class="font-weight-bold" @change="changeType">
             <option value="Taken">
               Taken by
             </option>
@@ -33,7 +33,7 @@
             v-model="selectedUser"
             autofocus
             :options="userOptions"
-            :class="'mb-2 ' + (selectedUser === -1 ? 'text-danger' : '')"
+            :class="'mb-2 font-weight-bold ' + (selectedUser === -1 ? 'text-danger' : '')"
           />
         </b-col>
       </b-row>
@@ -93,15 +93,13 @@
     </template>
   </b-modal>
 </template>
-<style scoped>
-select {
-  font-weight: bold;
-}
 
+<style scoped>
 option {
   color: black !important;
 }
 </style>
+
 <script>
 import Ratings from './Ratings'
 // TODO DESIGN We really want to push people to select a user.  How can we do that?  Can we force the select open on render?

--- a/components/PromiseModal.vue
+++ b/components/PromiseModal.vue
@@ -12,9 +12,9 @@
         You can change your mind later if it doesn't work out, using the  <em>Unpromise</em> button.
       </b-alert>
       <p>You're promising:</p>
-      <b-select v-model="selectedMessage" :options="messageOptions" class="mb-2" />
+      <b-select v-model="selectedMessage" :options="messageOptions" class="mb-2 font-weight-bold" />
       <p>...to:</p>
-      <b-select v-model="selectedUser" :options="userOptions" class="mb-2" />
+      <b-select v-model="selectedUser" :options="userOptions" class="mb-2 font-weight-bold" />
     </template>
     <template slot="modal-footer" slot-scope="{ ok, cancel }">
       <b-button variant="white" @click="cancel">
@@ -26,11 +26,10 @@
     </template>
   </b-modal>
 </template>
+
 <style scoped>
-select {
-  font-weight: bold;
-}
 </style>
+
 <script>
 // TODO DESIGN This is a good example of why I can't write mobile apps.  It's a very old-school interface, dropdown
 // lists, whereas perhaps it should be a all funky image-based touch-gesture stuff.

--- a/components/RenegeModal.vue
+++ b/components/RenegeModal.vue
@@ -11,9 +11,9 @@
         Please only do this if there's a good reason, so as not to disappoint people.
       </b-alert>
       <p>You're no longer promising:</p>
-      <b-select v-model="selectedMessage" :options="messageOptions" class="mb-2" disabled />
+      <b-select v-model="selectedMessage" :options="messageOptions" class="mb-2 font-weight-bold" disabled />
       <p>...to:</p>
-      <b-select v-model="selectedUser" :options="userOptions" class="mb-2" disabled />
+      <b-select v-model="selectedUser" :options="userOptions" class="mb-2 font-weight-bold" disabled />
     </template>
     <template slot="modal-footer" slot-scope="{ ok, cancel }">
       <b-button variant="white" @click="cancel">
@@ -25,11 +25,10 @@
     </template>
   </b-modal>
 </template>
+
 <style scoped>
-select {
-  font-weight: bold;
-}
 </style>
+
 <script>
 // TODO DESIGN This is a good example of why I can't write mobile apps.  It's a very old-school interface, dropdown
 // lists, whereas perhaps it should be a all funky image-based touch-gesture stuff.

--- a/components/ShareModal.vue
+++ b/components/ShareModal.vue
@@ -91,15 +91,10 @@
     </template>
   </b-modal>
 </template>
-<style scoped>
-select {
-  font-weight: bold;
-}
 
-option {
-  color: black !important;
-}
+<style scoped>
 </style>
+
 <script>
 export default {
   components: {},


### PR DESCRIPTION
There are quite a few element selectors in the code which is bad practice.  This is a first attempt at removing a few and using bootstrap selectors in their place.  The colour ones will have to wait until there is a standardised colour system in place.