### PR TITLE
Add a deep selector so that the class can be used in a child component

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -349,12 +349,6 @@ button {
     text-decoration: none;
 }
 
-/*TODO This gets stripped if we add it into Postcode because the element is added dynamically.  How do we avoid that?*/
-.pcinp {
-    max-width: 238px;
-    margin: 0 auto;
-}
-
 .iteminp ul {
     width: 100% !important;
     right: 0px !important;

--- a/components/Postcode.vue
+++ b/components/Postcode.vue
@@ -21,7 +21,8 @@
     </b-input-group-append>
   </b-input-group>
 </template>
-<style scoped>
+
+<style scoped lang="scss">
 .input-group,
 .autocomplete-wrapper,
 .input-group-append {
@@ -34,7 +35,14 @@
   left: -5px;
   position: relative;
 }
+
+/* Deep selector for scoped CSS */
+>>> .pcinp {
+  max-width: 238px;
+  margin: 0 auto;
+}
 </style>
+
 <script>
 import Autocomplete from '~/components/Autocomplete'
 // TODO Make find location button work


### PR DESCRIPTION
Use a deep selector so that the class can be used in a child component and not removed by the postcss process.

See here for a description
[https://vue-loader.vuejs.org/guide/scoped-css.html#child-component-root-elements](url)