### PR TITLE
Move iteminp class to where it is used

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -349,13 +349,6 @@ button {
     text-decoration: none;
 }
 
-.iteminp ul {
-    width: 100% !important;
-    right: 0px !important;
-    padding-right: 15px !important;
-    padding-left: 15px !important;
-}
-
 .postcodelist {
     z-index: 900;
 }

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -349,15 +349,6 @@ button {
     text-decoration: none;
 }
 
-.postcodelist {
-    z-index: 900;
-}
-
-.postcodelist li {
-    box-shadow: 1px 3px 5px 3px $color-black-opacity-60 !important;
-    width: 238px;
-}
-
 /* TODO I tried adding "appear" transitions, e.g. for elements in chitchat, or messages.  But they then don't
     show the computed emessage property.  Don't know why */
 .fade-enter-active, .fade-leave-active {

--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -52,6 +52,14 @@
   </div>
 </template>
 
+<style scoped>
+.iteminp ul {
+  width: 100% !important;
+  right: 0px !important;
+  padding-right: 15px !important;
+  padding-left: 15px !important;
+}
+</style>
 
 <script>
 /*! Copyright (c) 2016 Naufal Rabbani (http://github.com/BosNaufal)

--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -52,12 +52,25 @@
   </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@import 'color-vars';
+
+/* iteminp class is passed into this component in a prop */
 .iteminp ul {
   width: 100% !important;
   right: 0px !important;
   padding-right: 15px !important;
   padding-left: 15px !important;
+}
+
+/* postcodelist class is passed into this component in a prop */
+.postcodelist {
+  z-index: 900;
+}
+
+.postcodelist li {
+  box-shadow: 1px 3px 5px 3px $color-black-opacity-60;
+  width: 238px;
 }
 </style>
 


### PR DESCRIPTION
This class is only used with the autocomplete component so it should live with it.  There is then no issues with postcss removing it either.