### PR TITLE
To display an ellipsis for overflow the container needs a width.

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -124,12 +124,6 @@ div[variant="success"] .card-header {
   border-color: $colour-success-bg;
 }
 
-.chatname {
-  color: $colour-info-fg;
-  font-weight: bold;
-  white-space: nowrap;
-}
-
 .chatlist {
   max-height: calc(100vh - 74px);
   overflow-y: auto;

--- a/components/ChatListEntry.vue
+++ b/components/ChatListEntry.vue
@@ -41,12 +41,22 @@
     </b-row>
   </div>
 </template>
-<style scoped>
+
+<style scoped lang="scss">
+@import 'color-vars';
+
 img.profile {
   max-height: 25px !important;
   max-width: 25px !important;
 }
+
+.chatname {
+  color: $colour-info-fg;
+  font-weight: bold;
+  white-space: nowrap;
+}
 </style>
+
 <script>
 import twem from '~/assets/js/twem'
 

--- a/components/ChatPopup.vue
+++ b/components/ChatPopup.vue
@@ -20,13 +20,13 @@
               <b-col v-if="chat" class="pr-3">
                 <b-row>
                   <b-col class="p-0 pl-3">
-                    <span class="chatname">
-                      <span v-if="(chat.chattype == 'User2User' || chat.chattype == 'User2Mod')" class="d-inline">
+                    <span class="chatname text-truncate">
+                      <span v-if="(chat.chattype == 'User2User' || chat.chattype == 'User2Mod')">
                         <span @click="showInfo">
                           {{ chat.name }}
                         </span>
                       </span>
-                      <span v-else class="d-inline">
+                      <span v-else>
                         {{ chat.name }}
                       </span>
                     </span>
@@ -140,11 +140,9 @@
 }
 
 .chatname {
-  /* TODO DESIGN The ellipsis stuff here isn't working */
+  display: inline-block;
   max-width: 100px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-x: hidden;
+  font-weight: bold;
   color: $color-white;
 }
 


### PR DESCRIPTION
This fixes the ellipsis issue on the chat name.  To display an ellipsis you need a width. The issue was a width a set but the container was inline and so the width had no effect.