### PR TITLE
Fix up the design of the options and buttons.

### DIFF
--- a/components/Postcode.vue
+++ b/components/Postcode.vue
@@ -26,7 +26,8 @@
 
 <style scoped lang="scss">
 /* Deep selector for scoped CSS */
->>> .pcinp {
+::v-deep .pcinp {
+  min-width: 100px;
   max-width: 238px;
   margin: 0 auto;
 }

--- a/pages/find/whatisit.vue
+++ b/pages/find/whatisit.vue
@@ -51,23 +51,23 @@
               <b-card-body class="pt-0 pb-1">
                 <PostMessage :id="id" type="Wanted" />
               </b-card-body>
-              <b-card-footer v-if="index === ids.length - 1">
-                <div class="float-left">
+              <b-card-footer v-if="index === ids.length - 1" class="d-flex justify-content-between">
+                <div class="d-flex">
                   <Postcode :focus="false" :find="false" size="md" class="d-inline" @selected="postcodeSelect" />
-                  <ComposeGroup class="d-inline align-top" :width="200" />
-                </div>
-                <div class="ml-auto float-right">
-                  <b-btn v-if="ids.length > 1" variant="white" class="" @click="deleteItem">
-                    <v-icon name="trash-alt" />&nbsp;Delete item
-                  </b-btn>
-                  <b-btn variant="white" class="" @click="addItem">
-                    <v-icon name="plus" />&nbsp;Add another item
-                  </b-btn>
+                  <ComposeGroup :width="200" />
                 </div>
               </b-card-footer>
             </b-card>
           </li>
         </ul>
+        <div class="d-flex justify-content-end ml-1 mr-1">
+          <b-btn v-if="ids.length > 1" variant="white" class="mr-1" @click="deleteItem">
+            <v-icon name="trash-alt" />&nbsp;Delete item
+          </b-btn>
+          <b-btn variant="white" class="" @click="addItem">
+            <v-icon name="plus" />&nbsp;Add another item
+          </b-btn>
+        </div>
         <b-row>
           <b-col class="text-muted small pl-0 pt-1 text-center">
             We may show this post, but not your email address, to people who are not yet members of Freegle.

--- a/pages/give/whatisit.vue
+++ b/pages/give/whatisit.vue
@@ -51,23 +51,23 @@
               <b-card-body class="pt-0 pb-1">
                 <PostMessage :id="id" type="Offer" />
               </b-card-body>
-              <b-card-footer v-if="index === ids.length - 1">
-                <div class="mr-auto float-left">
+              <b-card-footer v-if="index === ids.length - 1" class="d-flex justify-content-between">
+                <div class="d-flex">
                   <Postcode :focus="false" :find="false" size="md" class="d-inline" @selected="postcodeSelect" />
-                  <ComposeGroup class="d-inline align-top" :width="200" />
-                </div>
-                <div class="ml-auto float-right">
-                  <b-btn v-if="ids.length > 1" variant="white" class="" @click="deleteItem">
-                    <v-icon name="trash-alt" />&nbsp;Delete last item
-                  </b-btn>
-                  <b-btn variant="white" class="" @click="addItem">
-                    <v-icon name="plus" />&nbsp;Add another item
-                  </b-btn>
+                  <ComposeGroup :width="200" />
                 </div>
               </b-card-footer>
             </b-card>
           </li>
         </ul>
+        <div class="d-flex justify-content-end ml-1 mr-1">
+          <b-btn v-if="ids.length > 1" variant="white" class="mr-1" @click="deleteItem">
+            <v-icon name="trash-alt" />&nbsp;Delete last item
+          </b-btn>
+          <b-btn variant="white" class="" @click="addItem">
+            <v-icon name="plus" />&nbsp;Add another item
+          </b-btn>
+        </div>
         <b-row>
           <b-col class="text-muted small pl-0 pt-1 text-center">
             We may show this post, but not your email address, to people who are not yet members of Freegle.


### PR DESCRIPTION
This is a bit of a redesign of the give page controls. Because of the narrow nature of the main section of the page, the design with the postcode, group, add and delete buttons in one row rapidly breaks.

The add and delete buttons aren`t actually directly related to an individual card and so they can be taken out into their own section.  That gives the whole area some breathing space and works at all breakpoints.

A further step would be to expand out the group control to fill up the remaining space in the row as many of the groups are too long to fit as it is.

Take a look and let me know what you think.