### PR TITLE
Sort out the date layout so it works across all breakpoints

### DIFF
--- a/assets/css/_color-vars.scss
+++ b/assets/css/_color-vars.scss
@@ -9,6 +9,7 @@ $colour-header: #1d6607;
 $colour-primary: #00A1CB;
 
 $color-green--light-alt: #00FF00;
+$color-green--lighter: #CDE4DA;
 $color-green--light: #E6ffE6;
 $color-green--medium: #84CF96;
 $color-green--dark: #3B8070;

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -1,4 +1,56 @@
 <template>
+  <!-- TODO This should be a fieldset within a form -->
+
+  <div class="form__element p-2 d-flex justify-content-between flex-column flex-lg-row align-items-md-end">
+    <div class="d-flex flex-column flex-md-row mb-3 mb-lg-0">
+      <div class="mr-0 mr-md-4 mb-3 mb-md-0 d-flex flex-column">
+        <label for="startDate" class="date__label">Starts at:</label>
+        <!-- Add form-control class to get focus etc. -->
+        <date-picker
+          id="startDate"
+          v-model="startd"
+          class=""
+          lang="en"
+          type="datetime"
+          append-to-body
+          format="ddd, Do MMM HH:mm a"
+          :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
+          placeholder=""
+          @change="change"
+        />
+      </div>
+      <div class="mr-lg-4 d-flex flex-column">
+        <label for="endDate" class="date__label">Ends at:</label>
+        <date-picker
+          id="endDate"
+          v-model="endd"
+          class=""
+          lang="en"
+          type="datetime"
+          append-to-body
+          format="ddd, Do MMM HH:mm a"
+          :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
+          placeholder=""
+          @change="change"
+        />
+      </div>
+    </div>
+    <div>
+      <!-- TODO This should be tabable to -->
+      <span title="Delete this date" class="d-none d-md-inline" @click="$emit('remove', index)">
+        <v-icon name="trash-alt" scale="1.5" />
+      </span>
+      <span title="Delete this date" class="d-inlineblock d-md-none">
+        <b-btn variant="white" class="mt-2 mb-3" size="sm" @click="$emit('remove', index)">
+          <v-icon name="trash-alt" /> Remove
+        </b-btn>
+      </span>
+    </div>
+
+
+
+    <!--
+
   <b-card no-body class="m-0 mb-1">
     <b-card-body class="p-2">
       <b-row>
@@ -47,9 +99,11 @@
       </b-row>
     </b-card-body>
   </b-card>
+-->
+  </div>
 </template>
+
 <script>
-// TODO DESIGN The vertical alignment is a bit rubbish in here, and there's probably a way to make this look nicer.
 export default {
   props: {
     start: {
@@ -85,3 +139,22 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+
+.form__element {
+  border: 1px solid $color-green--lighter;
+  border-radius: 0.25rem;
+}
+
+.date__label {
+  /* Override the style from bootstrap */
+  margin-bottom: 0;
+}
+
+/* Override the class from Vue2 Datepicker */
+.mx-datepicker {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
Fix the date layout in all breakpoints.

This resolves the following problems:

- I`ve moved the labels above the fields as this gives them more space as previously they would break almost instantly on smaller screens. Having the label about the field helps people scan better.
- Was previously set up as a bootstrap card which it isn`t really
- Remove the placeholders - Generally placeholders aren`t great for various reasons like accessibility, people can more easily scan for empty fields rather than fields already containing stuff, auto translate tools won`t translate them, when you start typing you lose the text etc.  The other fields should probably move the placeholder text into smaller text above or below the field