### PR TITLE
Enhancements/simplify delete button

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -78,7 +78,7 @@ $bootstrap-lg: 1200px;
   color: $color-black !important;
   text-shadow: none !important;
   -webkit-font-smoothing: antialiased;
-  border: 1px $color-black solid !important;
+  border: 1px $color-black solid;
 }
 
 .button--green {

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -38,7 +38,7 @@
     <div>
       <!-- TODO Hide button if only one date present -->
       <b-btn variant="white" class="delete__button" size="sm" @click="$emit('remove', index)">
-        <v-icon name="trash-alt" class="delete__icon" title="Delete this date" aria-hidden="true" />
+        <v-icon name="trash-alt" title="Delete this date" aria-hidden="true" />
         <span class="delete__label">Remove</span>
       </b-btn>
     </div>

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -37,7 +37,7 @@
     </div>
     <div>
       <!-- TODO Hide button if only one date present -->
-      <b-btn variant="white" class="delete__button" size="sm" @click="$emit('remove', index)">
+      <b-btn variant="white" size="sm" @click="$emit('remove', index)">
         <v-icon name="trash-alt" title="Delete this date" aria-hidden="true" />
         <span class="delete__label">Remove</span>
       </b-btn>
@@ -98,12 +98,6 @@ export default {
 /* Override the class from Vue2 Datepicker */
 .mx-datepicker {
   width: 100%;
-}
-
-.delete__button {
-  background-color: $color-white;
-  border: 1px solid $color-black;
-  border-radius: 0.2rem;
 }
 
 .delete__label {

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -38,7 +38,7 @@
     <div>
       <!-- TODO Hide button if only one date present -->
       <b-btn variant="white" class="delete__button" size="sm" @click="$emit('remove', index)">
-        <v-icon name="trash-alt" class="delete__icon" title="Delete this date" aria-label="Delete this date" />
+        <v-icon name="trash-alt" class="delete__icon" title="Delete this date" aria-hidden="true" />
         <span class="delete__label">Remove</span>
       </b-btn>
     </div>

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -36,70 +36,12 @@
       </div>
     </div>
     <div>
-      <!-- TODO This should be tabable to -->
-      <span title="Delete this date" class="d-none d-md-inline" @click="$emit('remove', index)">
-        <v-icon name="trash-alt" scale="1.5" />
-      </span>
-      <span title="Delete this date" class="d-inlineblock d-md-none">
-        <b-btn variant="white" class="mt-2 mb-3" size="sm" @click="$emit('remove', index)">
-          <v-icon name="trash-alt" /> Remove
-        </b-btn>
-      </span>
+      <!-- TODO Hide button if only one date present -->
+      <b-btn variant="white" class="delete__button" size="sm" @click="$emit('remove', index)">
+        <v-icon name="trash-alt" class="delete__icon" title="Delete this date" aria-label="Delete this date" />
+        <span class="delete__label">Remove</span>
+      </b-btn>
     </div>
-
-
-
-    <!--
-
-  <b-card no-body class="m-0 mb-1">
-    <b-card-body class="p-2">
-      <b-row>
-        <b-col cols="12" sm="5">
-          <span class="align-middle text-muted">
-            Starts at:
-          </span>
-          <date-picker
-            v-model="startd"
-            class="float-right mt-1"
-            lang="en"
-            type="datetime"
-            append-to-body
-            format="ddd, Do MMM HH:mm a"
-            :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
-            placeholder="Choose date/time"
-            @change="change"
-          />
-        </b-col>
-        <b-col cols="12" sm="5">
-          <span class="align-middle text-muted">
-            Ends at:
-          </span>
-          <date-picker
-            v-model="endd"
-            class="float-right mt-1"
-            lang="en"
-            type="datetime"
-            append-to-body
-            format="ddd, Do MMM HH:mm a"
-            :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
-            placeholder="Choose date/time"
-            @change="change"
-          />
-        </b-col>
-        <b-col cols="12" sm="2">
-          <span title="Delete this date" class="d-none d-sm-inline float-right" @click="$emit('remove', index)">
-            <v-icon name="trash-alt" scale="1.5" />
-          </span>
-          <span title="Delete this date" class="d-inlineblock d-sm-none">
-            <b-btn variant="white" class="mt-2 mb-3" size="sm" @click="$emit('remove', index)">
-              <v-icon name="trash-alt" /> Remove
-            </b-btn>
-          </span>
-        </b-col>
-      </b-row>
-    </b-card-body>
-  </b-card>
--->
   </div>
 </template>
 
@@ -156,5 +98,21 @@ export default {
 /* Override the class from Vue2 Datepicker */
 .mx-datepicker {
   width: 100%;
+}
+
+.delete__button {
+  background-color: $color-white;
+  border: 1px solid $color-black;
+  border-radius: 0.2rem;
+}
+
+.delete__label {
+  font-size: 14px;
+}
+
+/* Style the icon inside the v-icon component */
+.fa-icon {
+  width: auto;
+  height: 16px;
 }
 </style>


### PR DESCRIPTION
Simplify the delete button and make it tab-able.

Because there is now room, I`ve left the text in at all breakpoints.  Generally this is considered a good thing from a UX perspective.  If you don`t like the look then I can remove it on larger screens but then we would need to do some aria-fu.

I`ve had to remove the "important" for the white button border.  I`ve tested this hasn`t caused issues wherever I can but I might have missed something that we need to fix it later.

References:
https://css-tricks.com/do-you-need-an-icon-only-button-without-screwing-up-the-accessibility/
https://www.sarasoueidan.com/blog/accessible-icon-buttons/
