### PR TITLE
Move notification specific classes into their component.

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -259,11 +259,6 @@ button {
     opacity: 0;
 }
 
-.notiflist .dropdown-menu {
-    height: 500px;
-    overflow-y: auto;
-}
-
 .navbar .dropdown-toggle:after {
   content: none;
 }
@@ -321,13 +316,6 @@ nav .dropdown-toggle {
   hyphens: auto;
 }
 
-.notiflist .dropdown-item {
-  width: 300px;
-  max-width: 100%;
-  padding-left: 5px;
-  overflow-wrap: break-word;
-}
-
 .black {
   color: $color-black;
 }
@@ -367,11 +355,6 @@ nav .dropdown-toggle {
 
 legend {
   font-weight: bold !important;
-}
-
-.notpad > a {
-  padding-left: 0px;
-  padding-right: 0px;
 }
 
 .mx-datepicker-popup {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -79,7 +79,6 @@
                 </span>
               </infinite-loading>
             </b-nav-item-dropdown>
-            <a class="d-none dropdown-item" />
             <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @mousedown="maybeReload('/chats')">
               <div class="notifwrapper">
                 <v-icon name="comments" scale="2" /><br>
@@ -309,11 +308,6 @@ nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
   max-width: 100%;
   padding-left: 5px;
   overflow-wrap: break-word;
-}
-
-.dropdown-item {
-  padding-left: 0px;
-  padding-right: 0px;
 }
 
 .ourBack {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -294,12 +294,26 @@ nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
   margin: 0;
 }
 
-.dropdown-item {
-  padding-left: 0px;
-}
-
 .notiflist {
   max-width: 100%;
+}
+
+/* These classes style the external b-nav-item-dropdown component */
+.notiflist ::v-deep .dropdown-menu {
+  height: 500px;
+  overflow-y: auto;
+}
+
+.notiflist ::v-deep .dropdown-item {
+  width: 300px;
+  max-width: 100%;
+  padding-left: 5px;
+  overflow-wrap: break-word;
+}
+
+.dropdown-item {
+  padding-left: 0px;
+  padding-right: 0px;
 }
 
 .ourBack {
@@ -340,11 +354,6 @@ svg.fa-icon {
 .signindisabled {
   opacity: 0.2;
   pointer-events: none;
-}
-
-.dropdown-item {
-  padding-left: 0px;
-  padding-right: 0px;
 }
 
 .notifwrapper {


### PR DESCRIPTION
More clearing out of global styles.  Move the notification classes out of global and into the layout component.

Can the following element be removed?
`<a class="d-none dropdown-item" />`

Was it just added to sort out the previous `scoped` issue?  If so then I`ll remove it and re-test.
