### PR TITLE
Fix the issue with the bottom box floating to the top

### DIFF
--- a/components/SidebarLeft.vue
+++ b/components/SidebarLeft.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="d-flex flex-column sidebar__wrapper">
-    <CommunityEventSidebar v-if="showCommunityEvents" class="justify-content-start flex-grow-1" style="overflow-y: auto" />
-    <BotLeftBox v-if="showBotLeft" class="justify-content-end flex-shrink-2" />
-    <!--    TODO DESIGN If you set the events not to show, as on /mobile page, then the box appears wrongly at the top of the screen-->
+    <CommunityEventSidebar v-if="showCommunityEvents" class="flex-grow-1" style="overflow-y: auto" />
+    <BotLeftBox v-if="showBotLeft" class="social-media__wrapper flex-shrink-2" />
   </div>
 </template>
 
@@ -31,5 +30,9 @@ export default {
 <style scoped>
 .sidebar__wrapper {
   height: calc(100vh - 100px);
+}
+
+.social-media__wrapper {
+  margin-top: auto;
 }
 </style>


### PR DESCRIPTION
Fix the TODO
justify-content can only be used on the parent container and not the individual items so they weren`t having any effect.  There is currently no justify-self in flexbox and so an alternative solution is to add an auto top margin to the bottom box.