### PR TITLE
Refine GroupRememberSelect to work in edit forms

### DIFF
--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -335,7 +335,7 @@ export default {
             }
           ]
 
-      if (this.event.groups) {
+      if (this.event.groups && this.event.groups.length > 0) {
         this.groupid = this.event.groups[0].id
       }
     },

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -296,7 +296,7 @@ export default {
     return {
       showModal: false,
       editing: false,
-      groupid: 0,
+      groupid: null,
       uploading: false,
       oldphoto: null,
       olddates: null,
@@ -335,8 +335,9 @@ export default {
             }
           ]
 
-      // If we don't have any groups, force a select.
-      this.event.groups = this.event.groups ? this.event.groups : [{ id: 0 }]
+      if (this.event.groups) {
+        this.groupid = this.event.groups[0].id
+      }
     },
     hide() {
       this.editing = false

--- a/components/GroupRememberSelect.vue
+++ b/components/GroupRememberSelect.vue
@@ -32,7 +32,7 @@ export default {
   },
   computed: {
     rememberedValue() {
-      return this.$store.getters['group/remembered'](this.remember) || 0
+      return this.$store.getters['group/remembered'](this.remember)
     },
     selectValue: {
       get() {
@@ -40,10 +40,6 @@ export default {
       },
       set(val) {
         val = parseInt(val)
-        // value changed from the select
-        if (this.rememberedValue !== val) {
-          this.updateMemory(val)
-        }
         if (this.value !== val) {
           this.$emit('input', val)
         }
@@ -54,14 +50,16 @@ export default {
     rememberedValue: {
       immediate: true,
       handler(val) {
-        // value changed from the memory!
-        if (this.value !== val) {
-          this.$emit('input', val)
+        // value received from memory (might be nothing)
+        // we only take it if there is not already a value
+        // this ensures we don't override explicitly set values from outside
+        if (!this.value) {
+          this.$emit('input', val || 0)
         }
       }
     },
     value(val) {
-      // value changed from outside
+      // value changed
       if (this.rememberedValue !== val) {
         this.updateMemory(val)
       }
@@ -69,14 +67,14 @@ export default {
   },
   methods: {
     updateMemory(val) {
-      if (val === 0) {
-        this.$store.commit('group/forget', {
-          id: this.remember
-        })
-      } else {
+      if (val) {
         this.$store.commit('group/remember', {
           id: this.remember,
           val
+        })
+      } else {
+        this.$store.commit('group/forget', {
+          id: this.remember
         })
       }
     }

--- a/components/GroupRememberSelect.vue
+++ b/components/GroupRememberSelect.vue
@@ -5,6 +5,11 @@
 </template>
 <script>
 import groupSelect from './GroupSelect'
+
+function intOrNull(val) {
+  return typeof val === 'number' ? parseInt(val) : null
+}
+
 export default {
   components: {
     groupSelect
@@ -39,7 +44,7 @@ export default {
         return this.value
       },
       set(val) {
-        val = parseInt(val)
+        val = intOrNull(val)
         if (this.value !== val) {
           this.$emit('input', val)
         }
@@ -50,12 +55,10 @@ export default {
     rememberedValue: {
       immediate: true,
       handler(val) {
-        // value received from memory (might be nothing)
+        if (val === undefined) return // no remembered value
         // we only take it if there is not already a value
         // this ensures we don't override explicitly set values from outside
-        if (!this.value) {
-          this.$emit('input', val || 0)
-        }
+        if (this.value === null) this.$emit('input', val)
       }
     },
     value(val) {
@@ -67,7 +70,7 @@ export default {
   },
   methods: {
     updateMemory(val) {
-      if (val) {
+      if (typeof val === 'number') {
         this.$store.commit('group/remember', {
           id: this.remember,
           val

--- a/components/GroupSelect.vue
+++ b/components/GroupSelect.vue
@@ -12,6 +12,16 @@ select {
 <script>
 export default {
   props: {
+    /**
+     * Selected value
+     *
+     *   if null
+     *     if   all=true       --> "all groups"
+     *     else all=false      --> "you must select a group"
+     *   else if it's a number --> use that group id
+     *
+     * (0 is not a valid group number)
+     */
     value: {
       type: Number,
       default: null
@@ -43,22 +53,21 @@ export default {
 
       if (this.all) {
         groups.push({
-          value: 0,
+          value: null,
           text: '-- All my groups --',
-          selected: this.selectedGroup === 0
+          selected: this.selectedGroup === null
         })
       } else {
         groups.push({
-          value: 0,
+          value: null,
           text: '-- Please choose --',
-          selected: this.selectedGroup === -1
+          selected: this.selectedGroup === null
         })
       }
 
       const myGroups = this.$store.getters['auth/groups']()
-      Object.keys(myGroups).forEach(key => {
-        const group = myGroups[key]
 
+      for (const group of myGroups) {
         if (group.type === 'Freegle') {
           groups.push({
             value: group.id,
@@ -66,15 +75,26 @@ export default {
             selected: this.selectedGroup === group.id
           })
         }
-      })
+      }
 
-      groups.sort(function(a, b) {
-        const str1 = a.text
-        const str2 = b.text
-        return str1 < str2 ? -1 : str1 > str2 ? 1 : 0
-      })
+      groups.sort((a, b) => a.text.localeCompare(b.text))
 
       return groups
+    },
+
+    invalidSelection() {
+      return (
+        this.groupOptions.length > 0 &&
+        !this.groupOptions.some(option => option.selected)
+      )
+    }
+  },
+  watch: {
+    invalidSelection: {
+      immediate: true,
+      handler(val) {
+        if (val) this.selectedGroup = null
+      }
     }
   }
 }

--- a/components/VolunteerOpportunityModal.vue
+++ b/components/VolunteerOpportunityModal.vue
@@ -347,7 +347,7 @@ export default {
             }
           ]
 
-      if (this.volunteering.groups) {
+      if (this.volunteering.groups && this.volunteering.groups.length > 0) {
         this.groupid = this.volunteering.groups[0].id
       }
     },

--- a/components/VolunteerOpportunityModal.vue
+++ b/components/VolunteerOpportunityModal.vue
@@ -306,7 +306,7 @@ export default {
     return {
       showModal: false,
       editing: false,
-      groupid: 0,
+      groupid: null,
       uploading: false,
       oldphoto: null,
       olddates: null,
@@ -346,10 +346,9 @@ export default {
             }
           ]
 
-      // If we don't have any groups, force a select.
-      this.volunteering.groups = this.volunteering.groups
-        ? this.volunteering.groups
-        : [{ id: 0 }]
+      if (this.volunteering.groups) {
+        this.groupid = this.volunteering.groups[0].id
+      }
     },
     hide() {
       this.editing = false

--- a/components/VolunteerOpportunityModal.vue
+++ b/components/VolunteerOpportunityModal.vue
@@ -192,6 +192,7 @@
           When is it?
         </label>
         <p>You can add multiple dates if the opportunity occurs several times.</p>
+        <!-- TODO fix this to use v-model properly (as in components/CommunityEventModal.vue) -->
         <StartEndCollection v-if="volunteering.dates" :dates="volunteering.dates" @change="datesChange" />
         <label for="contactname">
           Contact name:

--- a/mixins/createGroupRoute.js
+++ b/mixins/createGroupRoute.js
@@ -34,6 +34,9 @@ export default function createGroupRoute(key, options = {}) {
   }
   return {
     computed: {
+      rememberedValue() {
+        return this.$store.getters['group/remembered'](rememberId)
+      },
       groupid: {
         get() {
           return this.$route.params[routeParam]
@@ -53,10 +56,10 @@ export default function createGroupRoute(key, options = {}) {
         }
       }
     },
-    created() {
-      this._unwatchGroupRemember = this.$store.watch(
-        (state, getters) => getters['group/remembered'](rememberId),
-        val => {
+    watch: {
+      rememberedValue: {
+        immediate: true,
+        handler(val) {
           if (val === undefined && this.groupid !== DEFAULT_VALUE) {
             // Nothing set so far... make it what our current page is
             this.updateMemory(this.groupid)
@@ -70,28 +73,22 @@ export default function createGroupRoute(key, options = {}) {
               this.updateMemory(this.groupid)
             }
           }
-        },
-        {
-          immediate: true
         }
-      )
+      }
     },
     methods: {
       updateMemory(val) {
         if (typeof val === 'number') {
           this.$store.commit('group/remember', {
-            id: this.remember,
+            id: rememberId,
             val
           })
         } else {
           this.$store.commit('group/forget', {
-            id: this.remember
+            id: rememberId
           })
         }
       }
-    },
-    beforeDestroy() {
-      if (this._unwatchGroupRemember) this._unwatchGroupRemember()
     }
   }
 }

--- a/mixins/createGroupRoute.js
+++ b/mixins/createGroupRoute.js
@@ -20,28 +20,34 @@
  * @returns a Vue mixin
  */
 export default function createGroupRoute(key, options = {}) {
-  const ALL_GROUPS = 0
+  const DEFAULT_VALUE = null
   const { routeParam = 'id' } = options
   const rememberId = key
+  function isGroupId(val) {
+    return typeof val === 'number' && val > 0
+  }
+  function groupIdOrNull(val) {
+    return isGroupId(val) ? val : null
+  }
   function routePath(id) {
-    return `/${key}/` + (id === ALL_GROUPS ? '' : id)
+    return `/${key}/${isGroupId(id) ? id : ''}`
   }
   return {
     computed: {
       groupid: {
         get() {
           return this.$route.params[routeParam]
-            ? parseInt(this.$route.params[routeParam])
-            : ALL_GROUPS
+            ? groupIdOrNull(parseInt(this.$route.params[routeParam]))
+            : DEFAULT_VALUE
         },
         set(val) {
           const oldVal = this.groupid
-          val = val || ALL_GROUPS
+          val = groupIdOrNull(val)
           if (val !== oldVal) {
             // We have changed the groupid away from the one in the route! Redirect...
             this.$router.push(routePath(val))
-            if (val === ALL_GROUPS) {
-              this.forgetGroup()
+            if (val === DEFAULT_VALUE) {
+              this.updateMemory(DEFAULT_VALUE)
             }
           }
         }
@@ -50,22 +56,18 @@ export default function createGroupRoute(key, options = {}) {
     created() {
       this._unwatchGroupRemember = this.$store.watch(
         (state, getters) => getters['group/remembered'](rememberId),
-        (val, oldVal) => {
-          if (
-            oldVal === undefined &&
-            val === undefined &&
-            this.groupid !== ALL_GROUPS
-          ) {
+        val => {
+          if (val === undefined && this.groupid !== DEFAULT_VALUE) {
             // Nothing set so far... make it what our current page is
-            this.rememberGroup()
+            this.updateMemory(this.groupid)
           } else if (val !== undefined) {
-            if (this.groupid === ALL_GROUPS) {
+            if (this.groupid === DEFAULT_VALUE) {
               // We have a remember value, but we're on the general page
               // Replace the current route
               this.$router.replace(routePath(val))
             } else if (this.groupid !== val) {
               // We've set the groupid to something else now, save it
-              this.rememberGroup()
+              this.updateMemory(this.groupid)
             }
           }
         },
@@ -75,16 +77,17 @@ export default function createGroupRoute(key, options = {}) {
       )
     },
     methods: {
-      rememberGroup() {
-        this.$store.commit('group/remember', {
-          id: rememberId,
-          val: this.groupid
-        })
-      },
-      forgetGroup() {
-        this.$store.commit('group/forget', {
-          id: rememberId
-        })
+      updateMemory(val) {
+        if (typeof val === 'number') {
+          this.$store.commit('group/remember', {
+            id: this.remember,
+            val
+          })
+        } else {
+          this.$store.commit('group/forget', {
+            id: this.remember
+          })
+        }
       }
     },
     beforeDestroy() {

--- a/pages/communities.vue
+++ b/pages/communities.vue
@@ -65,7 +65,7 @@ export default {
   data: function() {
     return {
       id: null,
-      groupid: 0,
+      groupid: null,
       messages: [],
       busy: false,
       context: null,

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -75,7 +75,7 @@ export default {
   },
   data() {
     return {
-      contactGroupId: 0,
+      contactGroupId: null,
       myItems: [
         {
           title: 'How do I post a WANTED?',

--- a/pages/unsubscribe.vue
+++ b/pages/unsubscribe.vue
@@ -62,7 +62,7 @@ export default {
   mixins: [loginOptional],
   data() {
     return {
-      groupid: 0,
+      groupid: null,
       leaving: false
     }
   },

--- a/store/communityevents.js
+++ b/store/communityevents.js
@@ -137,6 +137,7 @@ export const actions = {
       params: params
     })
 
+    // TODO this can return "ret":1,"status":"Not logged in", then res.data is not available and there is an error
     if (res.status === 200) {
       if (params && params.id) {
         commit('addAll', await dispatch('addFields', [res.data.communityevent]))


### PR DESCRIPTION
This fixes the issue that the GroupRememberSelect would give too much importance to the remember value. When editing an existing event, it should use the value from the event.

This changes it so that the remember value is only used where the value is not set (i.e. falsey) on the outer component, so it means setting groupid to null in the pages that use this component is required to get the correct behaviour.