### PR TITLE
Fix saving/editing community event dates

### DIFF
--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -172,7 +172,7 @@
           When is it?
         </label>
         <p>You can add multiple dates if the event occurs several times.</p>
-        <StartEndCollection v-if="event.dates" :dates="event.dates" @change="datesChange" />
+        <StartEndCollection v-if="event.dates" v-model="event.dates" />
         <label for="contactname">
           Contact name:
         </label>
@@ -273,8 +273,20 @@ export default {
   },
   props: {
     event: {
-      validator: prop => typeof prop === 'object' || prop === null,
-      required: true
+      // validator: prop => typeof prop === 'object' || prop === null,
+      // required: true
+      type: Object,
+      default: () => ({
+        title: null,
+        photo: null,
+        description: null,
+        location: null,
+        dates: [],
+        contactname: null,
+        contactemail: null,
+        contactphone: null,
+        contacturl: null
+      })
     },
     startEdit: {
       type: Boolean,
@@ -457,9 +469,6 @@ export default {
     },
     rotateRight() {
       this.rotate(-90)
-    },
-    datesChange(dates) {
-      this.event.dates = dates
     }
   }
 }

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -273,8 +273,6 @@ export default {
   },
   props: {
     event: {
-      // validator: prop => typeof prop === 'object' || prop === null,
-      // required: true
       type: Object,
       default: () => ({
         title: null,

--- a/components/StartEndCollection.vue
+++ b/components/StartEndCollection.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-for="(date, idx) in value" :key="date.uniqueid" :class="date.string && date.string.past ? 'inpast': ''">
-      <StartEndDate v-model="value[idx]" @remove="remove(idx)" />
+      <StartEndDate v-model="value[idx]" @remove="remove(date)" />
     </div>
     <b-btn variant="white" class="mt-1" @click="add">
       <v-icon name="plus" /> Add another date
@@ -44,8 +44,9 @@ export default {
     }
   },
   methods: {
-    remove(idx) {
-      this.value.splice(idx, 1)
+    remove(item) {
+      const idx = this.value.indexOf(item)
+      if (idx !== -1) this.value.splice(idx, 1)
     },
     async add() {
       this.value.push({

--- a/components/StartEndCollection.vue
+++ b/components/StartEndCollection.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <div v-for="date in editableDates" :key="'startend-' + date.uniqueid" :class="date.string && date.string.past ? 'inpast': ''">
-      <StartEndDate :start="date.start" :end="date.end" :uniqueid="date.uniqueid" @remove="remove(date.uniqueid)" @change="change(date)" />
+    <div v-for="(date, idx) in value" :key="date.uniqueid" :class="date.string && date.string.past ? 'inpast': ''">
+      <StartEndDate v-model="value[idx]" @remove="remove(idx)" />
     </div>
     <b-btn variant="white" class="mt-1" @click="add">
       <v-icon name="plus" /> Add another date
@@ -21,53 +21,39 @@
 <script>
 // TODO Validation - end date > start date, no stupidly long events (3 days?), no overlapping dates, only one blank slot.
 // TODO This code could do with a bit of extra testing - various combinations of add/edit/cancel/delete etc.
-const StartEndDate = () => import('~/components/StartEndDate')
+import StartEndDate from '~/components/StartEndDate'
 
 export default {
   components: {
     StartEndDate
   },
   props: {
-    dates: {
+    value: {
       type: Array,
       required: true
     }
   },
-  data: function() {
-    return {
-      editableDates: []
-    }
-  },
-  mounted: function() {
-    this.editableDates = this.dates ? this.dates : []
-  },
-  methods: {
-    remove(uniqueid) {
-      for (let i = 0; i < this.editableDates.length; i++) {
-        if (this.editableDates[i].uniqueid === uniqueid) {
-          this.editableDates.splice(i, 1)
-        }
-      }
-
-      this.$emit('change', JSON.stringify(this.editableDates))
-    },
-    add() {
-      this.editableDates.push({
-        uniqueid: this.$store.dispatch('uniqueid/generate'),
+  async mounted() {
+    if (this.value.length === 0) {
+      this.value.push({
+        uniqueid: await this.$store.dispatch('uniqueid/generate'),
         start: null,
         end: null,
         past: false
       })
+    }
+  },
+  methods: {
+    remove(idx) {
+      this.value.splice(idx, 1)
     },
-    change(date) {
-      for (let i = 0; i < this.editableDates.length; i++) {
-        console.log('Check', i)
-        if (this.editableDates[i].uniqueid === date.uniqueid) {
-          this.editableDates[i] = date
-        }
-      }
-
-      this.$emit('change', JSON.stringify(this.editableDates))
+    async add() {
+      this.value.push({
+        uniqueid: await this.$store.dispatch('uniqueid/generate'),
+        start: null,
+        end: null,
+        past: false
+      })
     }
   }
 }

--- a/components/StartEndDate.vue
+++ b/components/StartEndDate.vue
@@ -8,7 +8,7 @@
         <!-- Add form-control class to get focus etc. -->
         <date-picker
           id="startDate"
-          v-model="startd"
+          v-model="value.start"
           class=""
           lang="en"
           type="datetime"
@@ -16,14 +16,13 @@
           format="ddd, Do MMM HH:mm a"
           :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
           placeholder=""
-          @change="change"
         />
       </div>
       <div class="mr-lg-4 d-flex flex-column">
         <label for="endDate" class="date__label">Ends at:</label>
         <date-picker
           id="endDate"
-          v-model="endd"
+          v-model="value.end"
           class=""
           lang="en"
           type="datetime"
@@ -31,13 +30,12 @@
           format="ddd, Do MMM HH:mm a"
           :time-picker-options="{ start: '00:00', step: '00:30', end: '23:30' }"
           placeholder=""
-          @change="change"
         />
       </div>
     </div>
     <div>
       <!-- TODO Hide button if only one date present -->
-      <b-btn variant="white" size="sm" @click="$emit('remove', uniqueid)">
+      <b-btn variant="white" size="sm" @click="$emit('remove')">
         <v-icon name="trash-alt" title="Delete this date" aria-hidden="true" />
         <span class="delete__label">Remove</span>
       </b-btn>
@@ -48,36 +46,9 @@
 <script>
 export default {
   props: {
-    uniqueid: {
-      type: String,
+    value: {
+      type: Object,
       required: true
-    },
-    start: {
-      validator: prop => typeof prop === 'string' || prop === null,
-      required: true
-    },
-    end: {
-      validator: prop => typeof prop === 'string' || prop === null,
-      required: true
-    }
-  },
-  data: function() {
-    return {
-      startd: null,
-      endd: null
-    }
-  },
-  mounted: function() {
-    this.startd = this.start
-    this.endd = this.end
-  },
-  methods: {
-    change() {
-      this.$emit('change', {
-        uniqueid: this.uniqueid,
-        start: new Date(this.startd).toISOString(),
-        end: new Date(this.endd).toISOString()
-      })
     }
   }
 }

--- a/pages/communityevents/_id.vue
+++ b/pages/communityevents/_id.vue
@@ -34,7 +34,7 @@
       </b-col>
       <b-col cols="0" md="3" class="d-none d-md-block" />
     </b-row>
-    <CommunityEventModal ref="eventmodal" :event="{}" :start-edit="true" />
+    <CommunityEventModal ref="eventmodal" :start-edit="true" />
   </div>
 </template>
 <script>


### PR DESCRIPTION
The previous code would make a huge number of `AddDate` API calls. I _think_ this was actually because there was some `JSON.stringify()` calls being done on the start/end date object, which it was then iterating over. Not sure... I didn't look too deeply into that.

I had also noticed that the "event" data on the `CommunityEventModal` was not reactive (i.e. trying to print or watch values did not work). This was because the event object was defined as `{}` with no attributes, but used in the forms like `event.title`. This does not allow vue reactivity to work. So, the new approach is to define a default value function that gives null values to all the attributes that be used.

I reworked it to use `v-model` attributes where possible, this results in quite a lot of code/logic going away as we don't need manual change logic so much when we work directly on the values with v-model.

I would also propose to rework the `uniqueid/generate` implementation, I notice that existing dates (i.e. returned from the db, already have their database id, so we can use that as the key, so it's only for new entries that have yet to be saved. In the new approach, all that logic is contained within `StartEndCollection` so we can simply have a counter in that file (and make the keys like "new-1", "new-2", etc... ). The scope of the id is only for that single file, so no need to keep it in the global store.

... but I would wait for input from @edwh to go ahead with that.

... also, at some point would like to tackle validation and other concerns, lets see...!