### PR TITLE
Fix start end collection usage

### DIFF
--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -172,7 +172,7 @@
           When is it?
         </label>
         <p>You can add multiple dates if the event occurs several times.</p>
-        <StartEndCollection v-if="event.dates" v-model="event.dates" />
+        <StartEndCollection v-if="event.dates" v-model="event.dates" add-date-if-empty />
         <label for="contactname">
           Contact name:
         </label>

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -277,11 +277,13 @@ export default {
     event: {
       type: Object,
       default: () => ({
+        id: null,
         title: null,
         photo: null,
         description: null,
         location: null,
         dates: [],
+        groups: [],
         contactname: null,
         contactemail: null,
         contactphone: null,
@@ -315,7 +317,7 @@ export default {
     }
   },
   methods: {
-    async show() {
+    show() {
       this.editing = this.startEdit
       this.showModal = true
 
@@ -325,17 +327,6 @@ export default {
         this.event && this.event.dates
           ? JSON.parse(JSON.stringify(this.event.dates))
           : null
-
-      // If we don't have any dates, add an empty one so the slot appears for them to fill in.
-      this.event.dates = this.event.dates
-        ? this.event.dates
-        : [
-            {
-              start: null,
-              end: null,
-              uniqueid: await this.$store.dispatch('uniqueid/generate')
-            }
-          ]
 
       if (this.event.groups && this.event.groups.length > 0) {
         this.groupid = this.event.groups[0].id

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -260,6 +260,7 @@ label {
 // TODO Groups which don't support events
 // TODO Wherever we have b-img (throughout the site, not just here) we should have @brokenImage.  Bet we don't.
 // TODO Set date to start at 9am rather than midnight.  Default end date to later than start date.
+import cloneDeep from 'lodash.clonedeep'
 import twem from '~/assets/js/twem'
 const GroupRememberSelect = () => import('~/components/GroupRememberSelect')
 const OurFilePond = () => import('~/components/OurFilePond')
@@ -324,8 +325,8 @@ export default {
       this.oldphoto =
         this.event && this.event.photo ? this.event.photo.id : null
       this.olddates =
-        this.event && this.event.dates
-          ? JSON.parse(JSON.stringify(this.event.dates))
+        this.event && this.event.dates && this.event.dates.length > 0
+          ? cloneDeep(this.event.dates)
           : null
 
       if (this.event.groups && this.event.groups.length > 0) {

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -288,7 +288,8 @@ export default {
         contactname: null,
         contactemail: null,
         contactphone: null,
-        contacturl: null
+        contacturl: null,
+        canmodify: null
       })
     },
     startEdit: {

--- a/components/StartEndCollection.vue
+++ b/components/StartEndCollection.vue
@@ -4,7 +4,7 @@
       <StartEndDate v-model="value[idx]" @remove="remove(date)" />
     </div>
     <b-btn variant="white" class="mt-1" @click="add">
-      <v-icon name="plus" /> Add another date
+      <v-icon name="plus" /> Add <span v-if="value.length > 0">another</span><span v-else>a</span> date
     </b-btn>
   </div>
 </template>

--- a/components/StartEndCollection.vue
+++ b/components/StartEndCollection.vue
@@ -31,10 +31,14 @@ export default {
     value: {
       type: Array,
       required: true
+    },
+    addDateIfEmpty: {
+      type: Boolean,
+      default: false
     }
   },
   async mounted() {
-    if (this.value.length === 0) {
+    if (this.value.length === 0 && this.addDateIfEmpty) {
       this.value.push({
         uniqueid: await this.$store.dispatch('uniqueid/generate'),
         start: null,

--- a/components/VolunteerOpportunityModal.vue
+++ b/components/VolunteerOpportunityModal.vue
@@ -192,8 +192,7 @@
           When is it?
         </label>
         <p>You can add multiple dates if the opportunity occurs several times.</p>
-        <!-- TODO fix this to use v-model properly (as in components/CommunityEventModal.vue) -->
-        <StartEndCollection v-if="volunteering.dates" :dates="volunteering.dates" @change="datesChange" />
+        <StartEndCollection v-if="volunteering.dates" v-model="volunteering.dates" />
         <label for="contactname">
           Contact name:
         </label>
@@ -296,8 +295,24 @@ export default {
   },
   props: {
     volunteering: {
-      validator: prop => typeof prop === 'object' || prop === null,
-      required: true
+      type: Object,
+      default: () => ({
+        id: null,
+        title: null,
+        description: null,
+        photo: null,
+        user: null,
+        url: null,
+        timecommitment: null,
+        location: null,
+        dates: [],
+        groups: [],
+        contactname: null,
+        contactemail: null,
+        contactphone: null,
+        contacturl: null,
+        canmodify: null
+      })
     },
     startEdit: {
       type: Boolean,
@@ -338,16 +353,6 @@ export default {
         this.volunteering && this.volunteering.dates
           ? JSON.parse(JSON.stringify(this.volunteering.dates))
           : null
-
-      // If we don't have any dates, add an empty one so the slot appears for them to fill in.
-      this.volunteering.dates = this.volunteering.dates
-        ? this.volunteering.dates
-        : [
-            {
-              start: null,
-              end: null
-            }
-          ]
 
       if (this.volunteering.groups && this.volunteering.groups.length > 0) {
         this.groupid = this.volunteering.groups[0].id
@@ -493,9 +498,6 @@ export default {
     },
     rotateRight() {
       this.rotate(-90)
-    },
-    datesChange(dates) {
-      this.volunteering.dates = dates
     }
   }
 }

--- a/components/VolunteerOpportunityModal.vue
+++ b/components/VolunteerOpportunityModal.vue
@@ -280,6 +280,7 @@ label {
 // TODO Groups which don't support opportunities
 // TODO We used to have an "apply by" date. It's not clear we need this, so no urgency in re-adding it.
 // TODO EH Systemwide opportunities.
+import cloneDeep from 'lodash.clonedeep'
 import twem from '~/assets/js/twem'
 const GroupRememberSelect = () => import('~/components/GroupRememberSelect')
 const OurFilePond = () => import('~/components/OurFilePond')
@@ -350,8 +351,10 @@ export default {
           ? this.volunteering.photo.id
           : null
       this.olddates =
-        this.volunteering && this.volunteering.dates
-          ? JSON.parse(JSON.stringify(this.volunteering.dates))
+        this.volunteering &&
+        this.volunteering.dates &&
+        this.volunteering.dates.length > 0
+          ? cloneDeep(this.volunteering.dates)
           : null
 
       if (this.volunteering.groups && this.volunteering.groups.length > 0) {

--- a/pages/volunteering/_id.vue
+++ b/pages/volunteering/_id.vue
@@ -34,7 +34,7 @@
       </b-col>
       <b-col cols="0" md="3" class="d-none d-md-block" />
     </b-row>
-    <VolunteerOpportunityModal ref="volunteermodal" :volunteering="{}" :start-edit="true" />
+    <VolunteerOpportunityModal ref="volunteermodal" :start-edit="true" />
   </div>
 </template>
 


### PR DESCRIPTION
The main change is to correctly use `v-model` when using `StartEndCollection`. I had done this for community events, but omitted to do it for volunteerings.

Other related changes are:
- create default event for volunteering with all the fields nulled (allows reactivity to work as vue intended, matches how it works for community events)
- add a few extra fields to the default function for events and volunteerings (id and canmodify), probably not important, as they are only set for data that comes back from the API I think, but defining the fields up front seems nice to me (specifies what is available)
- use lodash's `cloneDeep` instead of `JSON.parse(JSON.stringify(data))` (which has data loss when using it with dates, which we do, see [explanation](https://stackoverflow.com/a/122704)), the library is already used on the site, so no extra page weight
- don't need to initialize `event|volunteering` dates on the modal page, `StartEndCollection` takes care of adding an empty event if needed now