### PR TITLE
Show notification count in page title

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -412,6 +412,13 @@ export default {
     }
   },
 
+  head() {
+    const totalCount = this.notificationCount + this.chatCount
+    return {
+      titleTemplate: totalCount > 0 ? `(${totalCount}) %s` : '%s'
+    }
+  },
+
   computed: {
     loggedIn() {
       const ret = Boolean(this.$store.getters['auth/user']())
@@ -427,19 +434,13 @@ export default {
       return notifications
     },
     notificationCount() {
-      // TODO NS We also need to change the window title.
       return this.$store.getters['notifications/count']()
     },
     chatCount() {
-      // TODO NS We also need to change the window title.
-      const chats = Object.values(this.$store.getters['chats/list']())
-      let count = 0
-
-      for (const chat of chats) {
-        count += chat.unseen
-      }
-
-      return count
+      return Object.values(this.$store.getters['chats/list']()).reduce(
+        (total, chat) => total + chat.unseen,
+        0
+      )
     },
     spreadCount() {
       return this.me && this.me.invitesleft ? this.me.invitesleft : 0

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -21,7 +21,7 @@ module.exports = {
   ** Headers of the page
   */
   head: {
-    title: pkg.name,
+    title: 'Freegle',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },


### PR DESCRIPTION
I used the _nuxt way_ with the [head()](https://nuxtjs.org/api/pages-head/) option. I kept it in the layout, given the counts are already calculated there, and the `head()` bit needs to go into a page/layout.

I also refactored the method to calculate the chat count using `reduce` function, seems perfect for that use case, but sometimes people don't understand how `reduce` works, what do you think?

Awaiting input on formatting for the title.