### PR TITLE
Fix Login Modal

### DIFF
--- a/components/LoginModal.vue
+++ b/components/LoginModal.vue
@@ -10,6 +10,8 @@
     size="lg"
     hide-footer
     no-close-on-backdrop
+    :hide-header-close="modalIsForced"
+    :no-close-on-esc="modalIsForced"
   >
     <b-row>
       <b-col class="text-center pb-3">
@@ -227,8 +229,17 @@ export default {
       return ret
     },
 
-    showModal() {
-      return this.pleaseShowModal || this.$store.getters['auth/forceLogin']()
+    showModal: {
+      get() {
+        return this.pleaseShowModal || this.$store.getters['auth/forceLogin']()
+      },
+      set(value) {
+        this.pleaseShowModal = value
+      }
+    },
+
+    modalIsForced() {
+      return this.$store.getters['auth/forceLogin']()
     },
 
     loggedInEver() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -153,11 +153,11 @@
 @import 'color-vars';
 
 .half-pad-col-right {
-  padding-right:7.5px;
+  padding-right: 7.5px;
 }
 
 .half-pad-col-left {
-  padding-left:7.5px;
+  padding-left: 7.5px;
 }
 
 .footer {


### PR DESCRIPTION
The Login Modal would not allow you to open it again after being closed. 

The computed `showModal` now has a setter and a getter to fix this issue.