### PR TITLE
Remove the nuxt loading bar

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -249,7 +249,6 @@
 
 /*TODO DESIGN Menu dropdown on mobile needs a bit of love.*/
 /*TODO DESIGN Shrink navbar on scroll? */
-/*TODO DESIGN MINOR There's a bar that appears at the top when an Ajax request is outstanding.  Probably a Nuxt thing.  It's a nice idea, but irksome.  Maybe just lose it, or have something less annoying on the navbar for the same purpose. /*
  */
 html {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,7 +33,7 @@ module.exports = {
   /*
   ** Customize the progress-bar color
   */
-  loading: { color: '#61AE24' },
+  loading: false,
 
   /*
   ** Global CSS


### PR DESCRIPTION
Remove the nuxt loading bar as per the TODO.

I've removed the bar in this PR but you can also style it or create your own.
[(https://nuxtjs.org/api/configuration-loading/)]

I'm not sure that it's particularly standard to have a page loading bar.  The browser will tell you the page is loading.  If the page is loading slowly enough to require telling the user then the page load speed should probably be increased. i.e. the task should be to investigate how to make the page load faster (or have a faster perceived load time e.g. image placeholders, load above the fold stuff first etc.)