### PR TITLE
Add API layer

### DIFF
--- a/api/ActivityAPI.js
+++ b/api/ActivityAPI.js
@@ -1,0 +1,7 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class ActivityAPI extends BaseAPI {
+  fetch() {
+    return this.$get()
+  }
+}

--- a/api/ActivityAPI.js
+++ b/api/ActivityAPI.js
@@ -2,6 +2,6 @@ import BaseAPI from '@/api/BaseAPI'
 
 export default class ActivityAPI extends BaseAPI {
   fetch() {
-    return this.$get()
+    return this.$get('/activity')
   }
 }

--- a/api/AddressAPI.js
+++ b/api/AddressAPI.js
@@ -1,0 +1,19 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class AddressAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get(params)
+  }
+
+  add(data) {
+    return this.$put(data)
+  }
+
+  update(data) {
+    return this.$patch(data)
+  }
+
+  del(id) {
+    return this.$del({ id })
+  }
+}

--- a/api/AddressAPI.js
+++ b/api/AddressAPI.js
@@ -2,18 +2,18 @@ import BaseAPI from '@/api/BaseAPI'
 
 export default class AddressAPI extends BaseAPI {
   fetch(params) {
-    return this.$get(params)
+    return this.$get('/address', params)
   }
 
   add(data) {
-    return this.$put(data)
+    return this.$put('/address', data)
   }
 
   update(data) {
-    return this.$patch(data)
+    return this.$patch('/address', data)
   }
 
   del(id) {
-    return this.$del({ id })
+    return this.$del('/address', { id })
   }
 }

--- a/api/AuthorityAPI.js
+++ b/api/AuthorityAPI.js
@@ -1,0 +1,7 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class AuthorityAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get('/authority', params)
+  }
+}

--- a/api/BaseAPI.js
+++ b/api/BaseAPI.js
@@ -6,31 +6,30 @@ export class APIError extends Error {
 }
 
 export default class BaseAPI {
-  constructor({ $axios, path }) {
+  constructor({ $axios }) {
     this.$axios = $axios
-    this.$path = path
   }
 
-  async $request(method, config) {
+  async $request(method, path, config) {
     const { status, data } = await this.$axios.request({
       ...config,
       method,
-      url: this.$path,
+      url: path,
       baseURL: process.env.API
     })
     if (status !== 200 || data.ret !== 0) {
       const message = [
         'API Error',
         method,
-        this.$path,
+        path,
         '->',
         `ret: ${data.ret} status: ${data.status || 'Unknown'}`
       ].join(' ')
       throw new APIError(
         {
           request: {
-            path: this.$path,
-            method: method,
+            path,
+            method,
             headers: config.headers,
             params: config.params,
             data: config.data
@@ -46,16 +45,16 @@ export default class BaseAPI {
     return data
   }
 
-  $get(params = {}) {
-    return this.$request('GET', { params })
+  $get(path, params = {}) {
+    return this.$request('GET', path, { params })
   }
 
-  $post(data) {
-    return this.$request('POST', { data })
+  $post(path, data) {
+    return this.$request('POST', path, { data })
   }
 
-  $postOverride(overrideMethod, data) {
-    return this.$request('POST', {
+  $postOverride(overrideMethod, path, data) {
+    return this.$request('POST', path, {
       data,
       headers: {
         'X-HTTP-Method-Override': overrideMethod
@@ -63,19 +62,19 @@ export default class BaseAPI {
     })
   }
 
-  $put(data) {
-    return this.$postOverride('PUT', data)
+  $put(path, data) {
+    return this.$postOverride('PUT', path, data)
   }
 
-  $realPut(data) {
-    return this.$request('PUT', { data })
+  $realPut(path, data) {
+    return this.$request('PUT', path, { data })
   }
 
-  $patch(data) {
-    return this.$postOverride('PATCH', data)
+  $patch(path, data) {
+    return this.$postOverride('PATCH', path, data)
   }
 
-  $del(data, config = {}) {
-    return this.$postOverride('DELETE', data)
+  $del(path, data, config = {}) {
+    return this.$postOverride('DELETE', path, data)
   }
 }

--- a/api/BaseAPI.js
+++ b/api/BaseAPI.js
@@ -39,6 +39,10 @@ export default class BaseAPI {
     return this.$postOverride('PUT', data)
   }
 
+  $realPut(data) {
+    return this.$request('PUT', { data })
+  }
+
   $patch(data) {
     return this.$postOverride('PATCH', data)
   }

--- a/api/BaseAPI.js
+++ b/api/BaseAPI.js
@@ -1,0 +1,49 @@
+export default class BaseAPI {
+  constructor({ $axios, path }) {
+    this.$axios = $axios
+    this.$path = path
+  }
+
+  async $request(method, config) {
+    const res = await this.$axios.request({
+      ...config,
+      method,
+      url: this.$path,
+      baseURL: process.env.API
+    })
+    if (res.status !== 200 || res.data.ret !== 0) {
+      console.error('API error', res)
+      throw new Error('API error')
+    }
+    return res.data
+  }
+
+  $get(params = {}) {
+    return this.$request('GET', { params })
+  }
+
+  $post(data) {
+    return this.$request('POST', { data })
+  }
+
+  $postOverride(overrideMethod, data) {
+    return this.$request('POST', {
+      data,
+      headers: {
+        'X-HTTP-Method-Override': overrideMethod
+      }
+    })
+  }
+
+  $put(data) {
+    return this.$postOverride('PUT', data)
+  }
+
+  $patch(data) {
+    return this.$postOverride('PATCH', data)
+  }
+
+  $del(data, config = {}) {
+    return this.$postOverride('DELETE', data)
+  }
+}

--- a/api/ChatAPI.js
+++ b/api/ChatAPI.js
@@ -5,6 +5,11 @@ export default class ChatAPI extends BaseAPI {
     return this.$get(`/chat/rooms/${chatid}/messages`, { limit, context })
   }
 
+  async listChats(params) {
+    const { chatrooms } = await this.$get('/chat/rooms', params)
+    return chatrooms
+  }
+
   fetchRoom(chatid) {
     return this.$get('/chatrooms', { id: chatid })
   }

--- a/api/ChatAPI.js
+++ b/api/ChatAPI.js
@@ -1,0 +1,30 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class ChatAPI extends BaseAPI {
+  fetch(chatid, { limit, context }) {
+    return this.$get(`/chat/rooms/${chatid}/messages`, { limit, context })
+  }
+
+  fetchRoom(chatid) {
+    return this.$get('/chatrooms', { id: chatid })
+  }
+
+  markSeen(chatid, lastmsg) {
+    return this.$post('/chatrooms', { id: chatid, lastmsgseen: lastmsg })
+  }
+
+  openChat(params) {
+    return this.$put('/chat/rooms', params)
+  }
+
+  send(data) {
+    return this.$post('/chatmessages', data)
+  }
+
+  nudge(roomid) {
+    return this.$post('/chatrooms', {
+      id: roomid,
+      action: 'Nudge'
+    })
+  }
+}

--- a/api/CommunityEventAPI.js
+++ b/api/CommunityEventAPI.js
@@ -2,38 +2,42 @@ import BaseAPI from '@/api/BaseAPI'
 
 export default class CommunityEventAPI extends BaseAPI {
   fetch(params) {
-    return this.$get(params)
+    return this.$get('/communityevent', params)
   }
 
   create(event) {
-    return this.$post(event)
+    return this.$post('/communityevent', event)
   }
 
   addGroup(id, groupid) {
-    return this.$patch({ id, groupid, action: 'AddGroup' })
+    return this.$patch('/communityevent', { id, groupid, action: 'AddGroup' })
   }
 
   removeGroup(id, groupid) {
-    return this.$patch({ id, groupid, action: 'RemoveGroup' })
+    return this.$patch('/communityevent', {
+      id,
+      groupid,
+      action: 'RemoveGroup'
+    })
   }
 
   setPhoto(id, photoid) {
-    return this.$patch({ id, photoid, action: 'SetPhoto' })
-  }
-
-  removeDate(id, dateid) {
-    return this.$patch({ id, dateid, action: 'RemoveDate' })
+    return this.$patch('/communityevent', { id, photoid, action: 'SetPhoto' })
   }
 
   addDate(id, start, end) {
-    return this.$patch({ id, start, end, action: 'RemoveDate' })
+    return this.$patch('/communityevent', { id, start, end, action: 'AddDate' })
+  }
+
+  removeDate(id, dateid) {
+    return this.$patch('/communityevent', { id, dateid, action: 'RemoveDate' })
   }
 
   save(event) {
-    return this.$patch(event)
+    return this.$patch('/communityevent', event)
   }
 
   del(id) {
-    return this.$del({ id })
+    return this.$del('/communityevent', { id })
   }
 }

--- a/api/CommunityEventAPI.js
+++ b/api/CommunityEventAPI.js
@@ -1,0 +1,60 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class CommunityEventAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get(params)
+  }
+
+  create(event) {
+    return this.$post(event)
+  }
+
+  addGroup(id, groupid) {
+    return this.$patch({
+      id,
+      groupid,
+      action: 'AddGroup'
+    })
+  }
+
+  removeGroup(id, groupid) {
+    return this.$patch({
+      id,
+      groupid,
+      action: 'RemoveGroup'
+    })
+  }
+
+  setPhoto(id, photoid) {
+    return this.$patch({
+      id,
+      photoid,
+      action: 'SetPhoto'
+    })
+  }
+
+  removeDate(id, dateid) {
+    return this.$patch({
+      id,
+      dateid,
+      action: 'RemoveDate'
+    })
+  }
+
+  addDate(id, start, end) {
+    return this.$patch({
+      id,
+      start,
+      end,
+      action: 'RemoveDate'
+    })
+  }
+
+  save(event) {
+    return this.$patch(event)
+  }
+
+  del(id) {
+    return this.$del({ id })
+  }
+}

--- a/api/CommunityEventAPI.js
+++ b/api/CommunityEventAPI.js
@@ -10,44 +10,23 @@ export default class CommunityEventAPI extends BaseAPI {
   }
 
   addGroup(id, groupid) {
-    return this.$patch({
-      id,
-      groupid,
-      action: 'AddGroup'
-    })
+    return this.$patch({ id, groupid, action: 'AddGroup' })
   }
 
   removeGroup(id, groupid) {
-    return this.$patch({
-      id,
-      groupid,
-      action: 'RemoveGroup'
-    })
+    return this.$patch({ id, groupid, action: 'RemoveGroup' })
   }
 
   setPhoto(id, photoid) {
-    return this.$patch({
-      id,
-      photoid,
-      action: 'SetPhoto'
-    })
+    return this.$patch({ id, photoid, action: 'SetPhoto' })
   }
 
   removeDate(id, dateid) {
-    return this.$patch({
-      id,
-      dateid,
-      action: 'RemoveDate'
-    })
+    return this.$patch({ id, dateid, action: 'RemoveDate' })
   }
 
   addDate(id, start, end) {
-    return this.$patch({
-      id,
-      start,
-      end,
-      action: 'RemoveDate'
-    })
+    return this.$patch({ id, start, end, action: 'RemoveDate' })
   }
 
   save(event) {

--- a/api/DashboardAPI.js
+++ b/api/DashboardAPI.js
@@ -1,0 +1,13 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class DashboardAPI extends BaseAPI {
+  async fetch(params) {
+    const { dashboard } = await this.$get('/dashboard', params)
+    return dashboard
+  }
+
+  async fetchHeatmap() {
+    const { heatmap } = await this.$get('/dashboard', { heatmap: true })
+    return heatmap
+  }
+}

--- a/api/DonationsAPI.js
+++ b/api/DonationsAPI.js
@@ -1,0 +1,11 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class DonationsAPI extends BaseAPI {
+  async fetch(groupid = null) {
+    const { target, raised } = await this.$get('/donations', { groupid })
+    return {
+      target: Math.round(parseInt(target)),
+      raised: Math.round(parseInt(raised))
+    }
+  }
+}

--- a/api/GroupAPI.js
+++ b/api/GroupAPI.js
@@ -1,0 +1,13 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class GroupAPI extends BaseAPI {
+  async list(params) {
+    const { groups } = await this.$get('/groups', params)
+    return groups
+  }
+
+  async fetch(id) {
+    const { group } = await this.$get('/group', { id })
+    return group
+  }
+}

--- a/api/InvitationAPI.js
+++ b/api/InvitationAPI.js
@@ -1,0 +1,20 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class InvitationAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get('/invitation', params)
+  }
+
+  async add(data) {
+    const { id } = await this.$post('/invitation', data)
+    return id
+  }
+
+  save(data) {
+    return this.$patch('/invitation', data)
+  }
+
+  del(id) {
+    return this.$del('/invitation', { id })
+  }
+}

--- a/api/JobAPI.js
+++ b/api/JobAPI.js
@@ -1,0 +1,8 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class JobAPI extends BaseAPI {
+  async fetch(params) {
+    const { data } = await this.$get('/adview.php', params)
+    return data
+  }
+}

--- a/api/MembershipsAPI.js
+++ b/api/MembershipsAPI.js
@@ -1,0 +1,15 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class MembershipsAPI extends BaseAPI {
+  update(data) {
+    return this.$patch(data)
+  }
+
+  joinGroup(data) {
+    return this.$put(data)
+  }
+
+  leaveGroup(data) {
+    return this.$del(data)
+  }
+}

--- a/api/MembershipsAPI.js
+++ b/api/MembershipsAPI.js
@@ -2,14 +2,14 @@ import BaseAPI from '@/api/BaseAPI'
 
 export default class MembershipsAPI extends BaseAPI {
   update(data) {
-    return this.$patch(data)
+    return this.$patch('/memberships', data)
   }
 
   joinGroup(data) {
-    return this.$put(data)
+    return this.$put('/memberships', data)
   }
 
   leaveGroup(data) {
-    return this.$del(data)
+    return this.$del('/memberships', data)
   }
 }

--- a/api/MessageAPI.js
+++ b/api/MessageAPI.js
@@ -1,0 +1,28 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class MessageAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get(params)
+  }
+
+  update(event) {
+    return this.$post(event)
+  }
+
+  save(event) {
+    return this.$patch(event)
+  }
+
+  joinAndPost(id, email) {
+    return this.$post({ id, email, action: 'JoinAndPost' })
+  }
+
+  del(id) {
+    return this.$del({ id })
+  }
+
+  // TODO: work out if this is actually needed like this...
+  put(data) {
+    return this.$realPut(data)
+  }
+}

--- a/api/MessageAPI.js
+++ b/api/MessageAPI.js
@@ -2,27 +2,31 @@ import BaseAPI from '@/api/BaseAPI'
 
 export default class MessageAPI extends BaseAPI {
   fetch(params) {
-    return this.$get(params)
+    return this.$get('/message', params)
+  }
+
+  fetchMessages(params) {
+    return this.$get('/messages', params)
   }
 
   update(event) {
-    return this.$post(event)
+    return this.$post('/message', event)
   }
 
   save(event) {
-    return this.$patch(event)
+    return this.$patch('/message', event)
   }
 
   joinAndPost(id, email) {
-    return this.$post({ id, email, action: 'JoinAndPost' })
+    return this.$post('/message', { id, email, action: 'JoinAndPost' })
   }
 
   del(id) {
-    return this.$del({ id })
+    return this.$del('/message', { id })
   }
 
   // TODO: work out if this is actually needed like this...
   put(data) {
-    return this.$realPut(data)
+    return this.$realPut('/message', data)
   }
 }

--- a/api/NewsAPI.js
+++ b/api/NewsAPI.js
@@ -1,0 +1,41 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class NewsAPI extends BaseAPI {
+  fetchFeed(params) {
+    return this.$get('/newsfeed', params)
+  }
+
+  async fetch(params) {
+    const { newsfeed } = await this.$get('newsfeed', params)
+    return newsfeed
+  }
+
+  async send(data) {
+    const { id } = await this.$post('/newsfeed', data)
+    return id
+  }
+
+  edit(id, message) {
+    return this.$patch('/newsfeed', { id, message, action: 'Edit' })
+  }
+
+  love(id) {
+    return this.$post('/newsfeed', { id, action: 'Love' })
+  }
+
+  unlove(id) {
+    return this.$post('/newsfeed', { id, action: 'Unlove' })
+  }
+
+  async unfollow(id) {
+    await this.$post('/newsfeed', { id, action: 'Unfollow' })
+  }
+
+  async report(id, reason) {
+    await this.$post('/newsfeed', { id, reason, action: 'Report' })
+  }
+
+  del(id) {
+    return this.$del('/newsfeed', { id })
+  }
+}

--- a/api/NoticeboardAPI.js
+++ b/api/NoticeboardAPI.js
@@ -1,0 +1,20 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class NoticeboardAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get('/noticeboard', params)
+  }
+
+  async add(data) {
+    const { id } = await this.$post('/noticeboard', data)
+    return id
+  }
+
+  save(data) {
+    return this.$patch('/noticeboard', data)
+  }
+
+  del(id) {
+    return this.$del('/noticeboard', { id })
+  }
+}

--- a/api/NotificationAPI.js
+++ b/api/NotificationAPI.js
@@ -1,0 +1,11 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class NotificationAPI extends BaseAPI {
+  seen(id) {
+    return this.$post('/notification', { id, action: 'Seen' })
+  }
+
+  allSeen() {
+    return this.$post('/notification', { action: 'AllSeen' })
+  }
+}

--- a/api/ScheduleAPI.js
+++ b/api/ScheduleAPI.js
@@ -1,0 +1,12 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class ScheduleAPI extends BaseAPI {
+  async fetch({ commit }, params) {
+    const { schedule } = await this.$get('/schedule', params)
+    return schedule
+  }
+
+  update(params) {
+    return this.$post('/schedule', params)
+  }
+}

--- a/api/SessionAPI.js
+++ b/api/SessionAPI.js
@@ -2,11 +2,11 @@ import BaseAPI from './BaseAPI'
 
 export default class SessionAPI extends BaseAPI {
   fetch(params) {
-    return this.$get(params)
+    return this.$get('/session', params)
   }
 
   save(data) {
-    return this.$patch(data)
+    return this.$patch('/session', data)
   }
 
   login({
@@ -17,7 +17,7 @@ export default class SessionAPI extends BaseAPI {
     googlelogin,
     googleauthcode
   }) {
-    return this.$post({
+    return this.$post('/session', {
       email,
       password,
       fblogin,
@@ -28,10 +28,10 @@ export default class SessionAPI extends BaseAPI {
   }
 
   logout() {
-    return this.$del()
+    return this.$del('/session')
   }
 
   forget() {
-    return this.$post({ action: 'Forget' })
+    return this.$post('/session', { action: 'Forget' })
   }
 }

--- a/api/SessionAPI.js
+++ b/api/SessionAPI.js
@@ -1,0 +1,37 @@
+import BaseAPI from './BaseAPI'
+
+export default class SessionAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get(params)
+  }
+
+  save(data) {
+    return this.$patch(data)
+  }
+
+  login({
+    email,
+    password,
+    fblogin,
+    fbaccesstoken,
+    googlelogin,
+    googleauthcode
+  }) {
+    return this.$post({
+      email,
+      password,
+      fblogin,
+      fbaccesstoken,
+      googlelogin,
+      googleauthcode
+    })
+  }
+
+  logout() {
+    return this.$del()
+  }
+
+  forget() {
+    return this.$post({ action: 'Forget' })
+  }
+}

--- a/api/StoriesAPI.js
+++ b/api/StoriesAPI.js
@@ -1,0 +1,20 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class StoriesAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get('/stories', params)
+  }
+
+  async add(data) {
+    const { id } = await this.$put('/stories', data)
+    return id
+  }
+
+  love(id) {
+    return this.$post('/stories', { id, action: 'Like' })
+  }
+
+  unlove(id) {
+    return this.$post('/stories', { id, action: 'Unlike' })
+  }
+}

--- a/api/TeamAPI.js
+++ b/api/TeamAPI.js
@@ -1,0 +1,8 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class TeamAPI extends BaseAPI {
+  async fetch(params) {
+    const { team } = await this.$get('/team', params)
+    return team
+  }
+}

--- a/api/UserAPI.js
+++ b/api/UserAPI.js
@@ -1,0 +1,12 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class UserAPI extends BaseAPI {
+  async fetch(params) {
+    const { user } = await this.$get('/user', params)
+    return user
+  }
+
+  rate(id, rating) {
+    return this.$post('/user', { ratee: id, rating, action: 'Rate' })
+  }
+}

--- a/api/UserSearchAPI.js
+++ b/api/UserSearchAPI.js
@@ -1,0 +1,12 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class UserSearchAPI extends BaseAPI {
+  async list(params) {
+    const { usersearches } = await this.$get('/usersearch', params)
+    return usersearches
+  }
+
+  del(id) {
+    return this.$del('/usersearch', { id })
+  }
+}

--- a/api/VolunteeringAPI.js
+++ b/api/VolunteeringAPI.js
@@ -1,0 +1,40 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class VolunteeringAPI extends BaseAPI {
+  fetch(params) {
+    return this.$get('/volunteering', params)
+  }
+
+  save(data) {
+    return this.$post('/volunteering', data)
+  }
+
+  async add(data) {
+    const { id } = await this.$post('/volunteering', data)
+    return id
+  }
+
+  addGroup(id, groupid) {
+    return this.$patch('/volunteering', { id, groupid, action: 'AddGroup' })
+  }
+
+  removeGroup(id, groupid) {
+    return this.$patch('/volunteering', { id, groupid, action: 'RemoveGroup' })
+  }
+
+  setPhoto(id, photoid) {
+    return this.$patch('/volunteering', { id, photoid, action: 'SetPhoto' })
+  }
+
+  addDate(id, start, end) {
+    return this.$patch('/volunteering', { id, start, end, action: 'AddDate' })
+  }
+
+  removeDate(id, dateid) {
+    return this.$patch('/volunteering', { id, dateid, action: 'RemoveDate' })
+  }
+
+  del(id) {
+    return this.$del('/volunteering', { id })
+  }
+}

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,25 +1,37 @@
-import ActivityAPI from './ActivityAPI'
-import AddressAPI from './AddressAPI'
-import AuthorityAPI from './AuthorityAPI'
-import ChatAPI from './ChatAPI'
-import CommunityEventAPI from './CommunityEventAPI'
-import DashboardAPI from './DashboardAPI'
-import DonationsAPI from './DonationsAPI'
-import GroupAPI from './GroupAPI'
-import InvitationAPI from './InvitationAPI'
-import JobAPI from './JobAPI'
-import MembershipsAPI from './MembershipsAPI'
-import MessageAPI from './MessageAPI'
-import NewsAPI from './NewsAPI'
-import NoticeboardAPI from './NoticeboardAPI'
-import NotificationAPI from './NotificationAPI'
-import ScheduleAPI from './ScheduleAPI'
-import SessionAPI from './SessionAPI'
-import StoriesAPI from './StoriesAPI'
-import TeamAPI from './TeamAPI'
-import UserAPI from './UserAPI'
-import UserSearchAPI from './UserSearchAPI'
-import VolunteeringAPI from './VolunteeringAPI'
+
+/*    --- DO NOT EDIT --- 
+ *
+ * This file was generating using api/index.generate.js
+ * You can regenerate it by running:
+ *
+ *     node api/index.generate.js
+ *
+ *    --- DO NOT EDIT ---
+ */
+
+
+import ActivityAPI from './ActivityAPI.js'
+import AddressAPI from './AddressAPI.js'
+import AuthorityAPI from './AuthorityAPI.js'
+import ChatAPI from './ChatAPI.js'
+import CommunityEventAPI from './CommunityEventAPI.js'
+import DashboardAPI from './DashboardAPI.js'
+import DonationsAPI from './DonationsAPI.js'
+import GroupAPI from './GroupAPI.js'
+import InvitationAPI from './InvitationAPI.js'
+import JobAPI from './JobAPI.js'
+import MembershipsAPI from './MembershipsAPI.js'
+import MessageAPI from './MessageAPI.js'
+import NewsAPI from './NewsAPI.js'
+import NoticeboardAPI from './NoticeboardAPI.js'
+import NotificationAPI from './NotificationAPI.js'
+import ScheduleAPI from './ScheduleAPI.js'
+import SessionAPI from './SessionAPI.js'
+import StoriesAPI from './StoriesAPI.js'
+import TeamAPI from './TeamAPI.js'
+import UserAPI from './UserAPI.js'
+import UserSearchAPI from './UserSearchAPI.js'
+import VolunteeringAPI from './VolunteeringAPI.js'
 
 interface API {
   activity: ActivityAPI;
@@ -32,8 +44,8 @@ interface API {
   group: GroupAPI;
   invitation: InvitationAPI;
   job: JobAPI;
-  message: MessageAPI;
   memberships: MembershipsAPI;
+  message: MessageAPI;
   news: NewsAPI;
   noticeboard: NoticeboardAPI;
   notification: NotificationAPI;

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,0 +1,13 @@
+import SessionAPI from './SessionAPI'
+import CommunityEventAPI from './CommunityEventAPI'
+
+interface API {
+  session: SessionAPI;
+  communityevent: CommunityEventAPI;
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $api: API;
+  }
+}

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,11 +1,17 @@
-import SessionAPI from './SessionAPI'
+import ActivityAPI from './ActivityAPI'
+import AddressAPI from './AddressAPI'
 import CommunityEventAPI from './CommunityEventAPI'
 import MessageAPI from './MessageAPI'
+import MembershipsAPI from './MembershipsAPI'
+import SessionAPI from './SessionAPI'
 
 interface API {
-  session: SessionAPI;
+  activity: ActivityAPI;
+  address: AddressAPI;
   communityevent: CommunityEventAPI;
   message: MessageAPI;
+  memberships: MembershipsAPI;
+  session: SessionAPI;
 }
 
 declare module 'vue/types/vue' {

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,9 +1,11 @@
 import SessionAPI from './SessionAPI'
 import CommunityEventAPI from './CommunityEventAPI'
+import MessageAPI from './MessageAPI'
 
 interface API {
   session: SessionAPI;
   communityevent: CommunityEventAPI;
+  message: MessageAPI;
 }
 
 declare module 'vue/types/vue' {

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,17 +1,49 @@
 import ActivityAPI from './ActivityAPI'
 import AddressAPI from './AddressAPI'
+import AuthorityAPI from './AuthorityAPI'
+import ChatAPI from './ChatAPI'
 import CommunityEventAPI from './CommunityEventAPI'
-import MessageAPI from './MessageAPI'
+import DashboardAPI from './DashboardAPI'
+import DonationsAPI from './DonationsAPI'
+import GroupAPI from './GroupAPI'
+import InvitationAPI from './InvitationAPI'
+import JobAPI from './JobAPI'
 import MembershipsAPI from './MembershipsAPI'
+import MessageAPI from './MessageAPI'
+import NewsAPI from './NewsAPI'
+import NoticeboardAPI from './NoticeboardAPI'
+import NotificationAPI from './NotificationAPI'
+import ScheduleAPI from './ScheduleAPI'
 import SessionAPI from './SessionAPI'
+import StoriesAPI from './StoriesAPI'
+import TeamAPI from './TeamAPI'
+import UserAPI from './UserAPI'
+import UserSearchAPI from './UserSearchAPI'
+import VolunteeringAPI from './VolunteeringAPI'
 
 interface API {
   activity: ActivityAPI;
   address: AddressAPI;
+  authority: AuthorityAPI;
+  chat: ChatAPI;
   communityevent: CommunityEventAPI;
+  dashboard: DashboardAPI;
+  donations: DonationsAPI;
+  group: GroupAPI;
+  invitation: InvitationAPI;
+  job: JobAPI;
   message: MessageAPI;
   memberships: MembershipsAPI;
+  news: NewsAPI;
+  noticeboard: NoticeboardAPI;
+  notification: NotificationAPI;
+  schedule: ScheduleAPI;
   session: SessionAPI;
+  stories: StoriesAPI;
+  team: TeamAPI;
+  user: UserAPI;
+  usersearch: UserSearchAPI;
+  volunteering: VolunteeringAPI;
 }
 
 declare module 'vue/types/vue' {

--- a/api/index.generate.js
+++ b/api/index.generate.js
@@ -1,0 +1,114 @@
+/**
+ * index.js and index.d.ts are very similar, and also both very boring files, just
+ * based on the files that are in this api/ directory, so we can generate them!
+ *
+ * Run it with:
+ *
+ *     node api/index.generate.js
+ *
+ *  It looks at all the files with the pattern "*API.js" (excluding BaseAPI.js).
+ *  It will generate and write two files:
+ *
+ *     api/index.js
+ *     api/index.d.ts
+ */
+
+const { readdirSync, writeFileSync } = require('fs')
+const { basename, join } = require('path')
+const prettier = require('prettier')
+const prettierConfig = prettier.resolveConfig.sync(
+  prettier.resolveConfigFile.sync()
+)
+
+const INDEX_FILENAME = join(__dirname, 'index.js')
+const TYPING_FILENAME = join(__dirname, 'index.d.ts')
+
+const DO_NOT_EDIT_WARNING = `
+/*    --- DO NOT EDIT --- 
+ *
+ * This file was generating using api/${basename(__filename)}
+ * You can regenerate it by running:
+ *
+ *     node api/${basename(__filename)}
+ *
+ *    --- DO NOT EDIT ---
+ */
+`
+
+const source = []
+
+const filenames = readdirSync(__dirname)
+
+function format(input) {
+  return prettier.format(input, {
+    parser: 'babylon',
+    ...prettierConfig
+  })
+}
+
+const entries = filenames
+  .filter(filename => /API.js$/.test(filename))
+  .filter(filename => filename !== 'BaseAPI.js')
+  .map(filename => {
+    const className = filename.replace(/\.js/, '')
+    const name = filename.replace(/API\.js$/, '').toLowerCase()
+    return { name, filename, className }
+  })
+
+function generateImports(entries) {
+  return entries
+    .map(
+      ({ className, filename }) => `import ${className} from './${filename}'`
+    )
+    .join('\n')
+}
+
+function generateIndex(entries) {
+  source.push(
+    DO_NOT_EDIT_WARNING,
+    '',
+    generateImports(entries),
+    '',
+    'export default ({ $axios }) => {',
+    'const options = { $axios }',
+    'return {'
+  )
+
+  source.push(
+    entries
+      .map(({ name, className }) => `${name}: new ${className}(options)`)
+      .join(',')
+  )
+
+  source.push('}}')
+
+  return format(source.join('\n'))
+}
+
+function generateTyping(entries) {
+  const source = []
+  source.push(
+    DO_NOT_EDIT_WARNING,
+    '',
+    generateImports(entries),
+    '',
+    'interface API {'
+  )
+  for (const { name, className } of entries) {
+    source.push(`  ${name}: ${className};`)
+  }
+  source.push(
+    '}',
+    '',
+    "declare module 'vue/types/vue' {",
+    '  interface Vue {',
+    '    $api: API;',
+    '  }',
+    '}'
+  )
+
+  return source.join('\n')
+}
+
+writeFileSync(INDEX_FILENAME, generateIndex(entries))
+writeFileSync(TYPING_FILENAME, generateTyping(entries))

--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,6 @@
-import SessionAPI from './SessionAPI'
+import SessionAPI from '@/api/SessionAPI'
 import CommunityEventAPI from '@/api/CommunityEventAPI'
+import MessageAPI from '@/api/MessageAPI'
 
 export default ({ $axios }) => {
   const options = { $axios }
@@ -12,6 +13,11 @@ export default ({ $axios }) => {
     communityevent: new CommunityEventAPI({
       ...options,
       path: '/communityevent'
+    }),
+
+    message: new MessageAPI({
+      ...options,
+      path: '/message'
     })
   }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,17 @@
+import SessionAPI from './SessionAPI'
+import CommunityEventAPI from '@/api/CommunityEventAPI'
+
+export default ({ $axios }) => {
+  const options = { $axios }
+  return {
+    session: new SessionAPI({
+      ...options,
+      path: '/session'
+    }),
+
+    communityevent: new CommunityEventAPI({
+      ...options,
+      path: '/communityevent'
+    })
+  }
+}

--- a/api/index.js
+++ b/api/index.js
@@ -1,23 +1,18 @@
-import SessionAPI from '@/api/SessionAPI'
-import CommunityEventAPI from '@/api/CommunityEventAPI'
-import MessageAPI from '@/api/MessageAPI'
+import ActivityAPI from './ActivityAPI'
+import AddressAPI from './AddressAPI'
+import CommunityEventAPI from './CommunityEventAPI'
+import MessageAPI from './MessageAPI'
+import MembershipsAPI from './MembershipsAPI'
+import SessionAPI from './SessionAPI'
 
 export default ({ $axios }) => {
-  const options = { $axios }
+  const options = path => ({ $axios, path })
   return {
-    session: new SessionAPI({
-      ...options,
-      path: '/session'
-    }),
-
-    communityevent: new CommunityEventAPI({
-      ...options,
-      path: '/communityevent'
-    }),
-
-    message: new MessageAPI({
-      ...options,
-      path: '/message'
-    })
+    activity: new ActivityAPI(options('/activity')),
+    address: new AddressAPI(options('/address')),
+    communityevent: new CommunityEventAPI(options('/communityevent')),
+    memberships: new MembershipsAPI(options('/memberships')),
+    message: new MessageAPI(options('/message')),
+    session: new SessionAPI(options('/session'))
   }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -1,18 +1,50 @@
 import ActivityAPI from './ActivityAPI'
 import AddressAPI from './AddressAPI'
+import AuthorityAPI from './AuthorityAPI'
+import ChatAPI from './ChatAPI'
 import CommunityEventAPI from './CommunityEventAPI'
-import MessageAPI from './MessageAPI'
+import DashboardAPI from './DashboardAPI'
+import DonationsAPI from './DonationsAPI'
+import GroupAPI from './GroupAPI'
+import InvitationAPI from './InvitationAPI'
+import JobAPI from './JobAPI'
 import MembershipsAPI from './MembershipsAPI'
+import MessageAPI from './MessageAPI'
+import NewsAPI from './NewsAPI'
+import NoticeboardAPI from './NoticeboardAPI'
+import NotificationAPI from './NotificationAPI'
+import ScheduleAPI from './ScheduleAPI'
 import SessionAPI from './SessionAPI'
+import StoriesAPI from './StoriesAPI'
+import TeamAPI from './TeamAPI'
+import UserAPI from './UserAPI'
+import UserSearchAPI from './UserSearchAPI'
+import VolunteeringAPI from './VolunteeringAPI'
 
 export default ({ $axios }) => {
-  const options = path => ({ $axios, path })
+  const options = { $axios }
   return {
-    activity: new ActivityAPI(options('/activity')),
-    address: new AddressAPI(options('/address')),
-    communityevent: new CommunityEventAPI(options('/communityevent')),
-    memberships: new MembershipsAPI(options('/memberships')),
-    message: new MessageAPI(options('/message')),
-    session: new SessionAPI(options('/session'))
+    activity: new ActivityAPI(options),
+    address: new AddressAPI(options),
+    authority: new AuthorityAPI(options),
+    chat: new ChatAPI(options),
+    communityevent: new CommunityEventAPI(options),
+    dashboard: new DashboardAPI(options),
+    donations: new DonationsAPI(options),
+    group: new GroupAPI(options),
+    invitation: new InvitationAPI(options),
+    job: new JobAPI(options),
+    memberships: new MembershipsAPI(options),
+    news: new NewsAPI(options),
+    noticeboard: new NoticeboardAPI(options),
+    notification: new NotificationAPI(options),
+    message: new MessageAPI(options),
+    schedule: new ScheduleAPI(options),
+    session: new SessionAPI(options),
+    stories: new StoriesAPI(options),
+    team: new TeamAPI(options),
+    user: new UserAPI(options),
+    usersearch: new UserSearchAPI(options),
+    volunteering: new VolunteeringAPI(options)
   }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -1,25 +1,35 @@
-import ActivityAPI from './ActivityAPI'
-import AddressAPI from './AddressAPI'
-import AuthorityAPI from './AuthorityAPI'
-import ChatAPI from './ChatAPI'
-import CommunityEventAPI from './CommunityEventAPI'
-import DashboardAPI from './DashboardAPI'
-import DonationsAPI from './DonationsAPI'
-import GroupAPI from './GroupAPI'
-import InvitationAPI from './InvitationAPI'
-import JobAPI from './JobAPI'
-import MembershipsAPI from './MembershipsAPI'
-import MessageAPI from './MessageAPI'
-import NewsAPI from './NewsAPI'
-import NoticeboardAPI from './NoticeboardAPI'
-import NotificationAPI from './NotificationAPI'
-import ScheduleAPI from './ScheduleAPI'
-import SessionAPI from './SessionAPI'
-import StoriesAPI from './StoriesAPI'
-import TeamAPI from './TeamAPI'
-import UserAPI from './UserAPI'
-import UserSearchAPI from './UserSearchAPI'
-import VolunteeringAPI from './VolunteeringAPI'
+/*    --- DO NOT EDIT --- 
+ *
+ * This file was generating using api/index.generate.js
+ * You can regenerate it by running:
+ *
+ *     node api/index.generate.js
+ *
+ *    --- DO NOT EDIT ---
+ */
+
+import ActivityAPI from './ActivityAPI.js'
+import AddressAPI from './AddressAPI.js'
+import AuthorityAPI from './AuthorityAPI.js'
+import ChatAPI from './ChatAPI.js'
+import CommunityEventAPI from './CommunityEventAPI.js'
+import DashboardAPI from './DashboardAPI.js'
+import DonationsAPI from './DonationsAPI.js'
+import GroupAPI from './GroupAPI.js'
+import InvitationAPI from './InvitationAPI.js'
+import JobAPI from './JobAPI.js'
+import MembershipsAPI from './MembershipsAPI.js'
+import MessageAPI from './MessageAPI.js'
+import NewsAPI from './NewsAPI.js'
+import NoticeboardAPI from './NoticeboardAPI.js'
+import NotificationAPI from './NotificationAPI.js'
+import ScheduleAPI from './ScheduleAPI.js'
+import SessionAPI from './SessionAPI.js'
+import StoriesAPI from './StoriesAPI.js'
+import TeamAPI from './TeamAPI.js'
+import UserAPI from './UserAPI.js'
+import UserSearchAPI from './UserSearchAPI.js'
+import VolunteeringAPI from './VolunteeringAPI.js'
 
 export default ({ $axios }) => {
   const options = { $axios }
@@ -35,10 +45,10 @@ export default ({ $axios }) => {
     invitation: new InvitationAPI(options),
     job: new JobAPI(options),
     memberships: new MembershipsAPI(options),
+    message: new MessageAPI(options),
     news: new NewsAPI(options),
     noticeboard: new NoticeboardAPI(options),
     notification: new NotificationAPI(options),
-    message: new MessageAPI(options),
     schedule: new ScheduleAPI(options),
     session: new SessionAPI(options),
     stories: new StoriesAPI(options),

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -360,7 +360,8 @@ export default {
           })
         }
 
-        const oldgroupid = this.event.groups ? this.event.groups[0].id : null
+        const oldgroupid =
+          this.event.groups.length > 0 ? this.event.groups[0].id : null
 
         if (this.groupid !== oldgroupid) {
           // Save the new group, then remove the old group, so it won't get stranded.

--- a/components/NewsCommunityEvent.vue
+++ b/components/NewsCommunityEvent.vue
@@ -19,7 +19,9 @@
         <span class="text-muted small">
           {{ $dayjs(newsfeed.timestamp).fromNow() }}
         </span>
-        on {{ newsfeed.communityevent.groups[0].namedisplay }}
+        <span v-if="newsfeed.communityevent.groups.length > 0">
+          on {{ newsfeed.communityevent.groups[0].namedisplay }}
+        </span>
       </b-col>
     </b-row>
     <b-row>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,8 +65,6 @@ module.exports = {
     // Iznik $api setup
     { src: '~plugins/api.js' },
 
-    { src: '~plugins/error-toasts.js' },
-
     // Our parameters serialize differently from axios defaults
     { src: '~plugins/axios-serializer.js' },
     { src: '~plugins/axios-login.js' },
@@ -81,6 +79,7 @@ module.exports = {
     { src: '~/plugins/dayjs'},
 
     // Some plugins are client-side features
+    { src: '~plugins/error-toasts.js', ssr: false },
     { src: '~plugins/vuex-persistedstate', ssr: false },
     { src: '~plugins/vue-drag-drop.js', ssr: false },
     { src: '~plugins/vue-draggable-resizable.js', ssr: false },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -62,6 +62,9 @@ module.exports = {
     // Our directives
     '~/plugins/directives',
 
+    // Iznik $api setup
+    { src: '~plugins/api.js' },
+
     // Our parameters serialize differently from axios defaults
     { src: '~plugins/axios-serializer.js' },
     { src: '~plugins/axios-login.js' },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,6 +65,8 @@ module.exports = {
     // Iznik $api setup
     { src: '~plugins/api.js' },
 
+    { src: '~plugins/error-toasts.js' },
+
     // Our parameters serialize differently from axios defaults
     { src: '~plugins/axios-serializer.js' },
     { src: '~plugins/axios-login.js' },
@@ -171,7 +173,8 @@ module.exports = {
       'ProgressPlugin',
       'TabsPlugin',
       'TablePlugin',
-      'TooltipPlugin'
+      'TooltipPlugin',
+      'BVToastPlugin'
     ],
     directivePlugins: ['VBPopoverPlugin', 'VBTooltipPlugin', 'VBScrollspyPlugin']
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8267,8 +8267,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "balanced-match": {
@@ -8350,7 +8350,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
@@ -8365,14 +8365,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "glob": {
@@ -8381,12 +8381,12 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-unicode": {
@@ -8419,8 +8419,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -8471,8 +8471,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
@@ -8481,7 +8481,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
@@ -8516,16 +8516,16 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.3.0",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.4.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.8",
-                "rimraf": "2.6.3",
-                "semver": "5.7.0",
-                "tar": "4.4.8"
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
               }
             },
             "nopt": {
@@ -8560,10 +8560,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
@@ -8584,7 +8584,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -8647,13 +8647,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "rimraf": {
@@ -8662,7 +8662,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
@@ -8742,13 +8742,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "chownr": "1.1.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.3.5",
-                "minizlib": "1.2.1",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
               }
             },
             "util-deprecate": {
@@ -8763,7 +8763,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,0 +1,5 @@
+import api from '~/api'
+
+export default (ctx, inject) => {
+  inject('api', api(ctx))
+}

--- a/plugins/error-toasts.js
+++ b/plugins/error-toasts.js
@@ -1,0 +1,21 @@
+import Vue from 'vue'
+import { APIError } from '@/api/BaseAPI'
+
+export default () => {
+  const originalErrorHandler = Vue.config.errorHandler
+  Vue.config.errorHandler = (err, vm, info, ...rest) => {
+    if (err instanceof APIError && vm.$bvToast) {
+      const { request, response } = err
+      console.error(err, { request, response })
+      vm.$bvToast.toast('Sorry, we messed something up!', {
+        title: response.data.status,
+        variant: 'danger',
+        toaster: 'b-toaster-bottom-center',
+        autoHideDelay: 5000,
+        appendToast: true
+      })
+      return true
+    }
+    return originalErrorHandler(err, vm, info, ...rest)
+  }
+}

--- a/plugins/error-toasts.js
+++ b/plugins/error-toasts.js
@@ -1,18 +1,27 @@
 import Vue from 'vue'
 import { APIError } from '@/api/BaseAPI'
 
+const TOAST_EMAIL = 'support@ilovefreegle.org'
+const TOAST_TITLE = 'Sorry, something went wrong'
+const TOAST_MESSAGE = `
+  That might be a bug.
+  Please try again - if you continue to have problems then
+  please take a screenshot and contact ${TOAST_EMAIL}
+`
+
 export default () => {
   const originalErrorHandler = Vue.config.errorHandler
   Vue.config.errorHandler = (err, vm, info, ...rest) => {
     if (err instanceof APIError && vm.$bvToast) {
       const { request, response } = err
       console.error(err, { request, response })
-      vm.$bvToast.toast('Sorry, we messed something up!', {
-        title: response.data.status,
+      vm.$bvToast.toast(TOAST_MESSAGE, {
+        title: TOAST_TITLE,
         variant: 'danger',
         toaster: 'b-toaster-bottom-center',
-        autoHideDelay: 5000,
-        appendToast: true
+        autoHideDelay: 10000,
+        appendToast: true,
+        solid: true
       })
       return true
     }

--- a/store/activity.js
+++ b/store/activity.js
@@ -28,11 +28,7 @@ export const getters = {
 
 export const actions = {
   async fetchRecentMessages({ commit }) {
-    const res = await this.$axios.get(process.env.API + '/activity')
-
-    if (res.status === 200) {
-      commit('setRecentMessages', res.data.recentmessages)
-    }
+    commit('setRecentMessages', await this.$api.activity.fetch())
   },
 
   clearRecentMessages({ commit }) {

--- a/store/address.js
+++ b/store/address.js
@@ -76,76 +76,35 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/address', {
-      params: params
-    })
-
-    if (res.status === 200 && res.data.ret === 0) {
-      if (res.data.addresses) {
-        commit('clear')
-        commit('set', res.data.addresses)
-      } else {
-        commit('set', [res.data.address])
-      }
+    const { addresses, address } = await this.$api.address.fetch(params)
+    if (addresses) {
+      commit('clear')
+      commit('set', addresses)
+    } else {
+      commit('set', [address])
     }
   },
 
   async fetchProperties({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/address', {
-      params: params
-    })
-
-    if (res.status === 200 && res.data.ret === 0) {
-      commit('clearProperties')
-      commit('setProperties', res.data.addresses)
-    }
+    const { addresses } = await this.$api.address.fetch(params)
+    commit('clearProperties')
+    commit('setProperties', addresses)
   },
 
   async delete({ commit, getters, dispatch }, params) {
-    await this.$axios.post(
-      process.env.API + '/address',
-      {
-        id: params.id
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
+    await this.$api.address.del(params.id)
     await dispatch('fetch')
   },
 
   async add({ commit, getters, dispatch }, params) {
-    let id = null
-    const ret = await this.$axios.post(process.env.API + '/address', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PUT'
-      }
-    })
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      await dispatch('fetch', {
-        id: ret.data.id
-      })
-
-      id = ret.data.id
-    }
-
+    const { id } = await this.$api.address.add(params)
+    await dispatch('fetch', { id })
     return id
   },
 
   async update({ commit, getters, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/address', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PATCH'
-      }
-    })
-
-    await dispatch('fetch', {
-      id: params.id
-    })
+    await this.$api.address.update(params)
+    await dispatch('fetch', { id: params.id })
   },
 
   select({ commit }, id) {

--- a/store/auth.js
+++ b/store/auth.js
@@ -239,58 +239,24 @@ export const actions = {
   },
 
   async setGroup({ commit, dispatch, state }, params) {
-    await this.$axios.post(process.env.API + '/memberships', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PATCH'
-      }
-    })
+    await this.$api.memberships.update(params)
   },
 
   async leaveGroup({ commit, dispatch, state }, params) {
-    const res = await this.$axios.post(
-      process.env.API + '/memberships',
-      params,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
-    if (res.status === 200 && res.data.ret === 0) {
-      await dispatch('fetchUser', {
-        components: NONMIN,
-        force: true
-      })
-    } else {
-      // TODO
-      console.error('saveUser failed')
-    }
-
+    await this.$api.memberships.leaveGroup(params)
+    await dispatch('fetchUser', {
+      components: NONMIN,
+      force: true
+    })
     return state.user
   },
 
   async joinGroup({ commit, dispatch, state }, params) {
-    const res = await this.$axios.post(
-      process.env.API + '/memberships',
-      params,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PUT'
-        }
-      }
-    )
-
-    if (res.status === 200 && res.data.ret === 0) {
-      await dispatch('fetchUser', {
-        components: NONMIN,
-        force: true
-      })
-    } else {
-      // TODO
-      console.error('saveUser failed')
-    }
-
+    await this.$api.memberships.joinGroup(params)
+    await dispatch('fetchUser', {
+      components: NONMIN,
+      force: true
+    })
     return state.user
   },
 

--- a/store/authorities.js
+++ b/store/authorities.js
@@ -48,13 +48,8 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/authority', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('setList', params.id ? [res.data.authority] : res.data.authorities)
-    }
+    const { authority, authorities } = await this.$api.authority.fetch()
+    commit('setList', params.id ? [authority] : authorities)
   },
 
   clear({ commit }) {

--- a/store/chats.js
+++ b/store/chats.js
@@ -78,52 +78,20 @@ export const actions = {
   },
 
   async openChat({ dispatch, commit }, params) {
-    let id = null
-
-    const res = await this.$axios.post(
-      process.env.API + '/chat/rooms',
-      params,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PUT'
-        }
-      }
-    )
-
-    if (res.status === 200) {
-      id = res.data.id
-
-      await dispatch('fetch', {
-        id: id
-      })
-    }
-
+    const { id } = await this.$api.chat.openChat(params)
+    await dispatch('fetch', { id })
     return id
   },
 
-  async fetch({ commit }, params) {
-    const chatid = params.id
-
-    if (chatid) {
-      const chat = await this.$axios.get(process.env.API + '/chatrooms', {
-        params: {
-          id: chatid
-        }
-      })
-
-      if (chat.status === 200 && chat.data.ret === 0) {
-        const chatobj = chat.data.chatroom
-
-        if (chatobj) {
-          // Valid chatid
-          commit('addRoom', chatobj)
-        } else {
-          // Invalid
-          console.error('Invalid chat id', chatid)
-        }
-      }
+  async fetch({ commit }, { id: chatid }) {
+    if (!chatid) return
+    const { chatroom } = await this.$api.chat.fetchRoom(chatid)
+    if (chatroom) {
+      // Valid chatid
+      commit('addRoom', chatroom)
     } else {
-      console.error("Don't fetch null id")
+      // Invalid
+      console.error('Invalid chat id', chatid)
     }
   },
 
@@ -131,12 +99,7 @@ export const actions = {
     const chat = getters.get(params.id)
 
     if (chat.unseen > 0) {
-      // Record that we have seen the last message, and there are no unseen ones left.
-      await this.$axios.post(process.env.API + '/chatrooms', {
-        id: chat.id,
-        lastmsgseen: chat.lastmsg
-      })
-
+      await this.$api.chat.markSeen(chat.id, chat.lastmsg)
       await dispatch('fetch', {
         id: params.id
       })

--- a/store/chats.js
+++ b/store/chats.js
@@ -49,14 +49,7 @@ export const actions = {
       summary: true,
       search: params && params.search ? params.search : null
     }
-
-    const res = await this.$axios.get(process.env.API + '/chat/rooms', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('setList', res.data.chatrooms)
-    }
+    commit('setList', await this.$api.chat.listChats(params))
   },
 
   async openChatToMods({ dispatch, commit }, params) {

--- a/store/donations.js
+++ b/store/donations.js
@@ -23,17 +23,6 @@ export const getters = {
 export const actions = {
   async fetch({ commit }, params) {
     console.log('Fetch donations', params)
-    const donations = await this.$axios.get(process.env.API + '/donations', {
-      params: {
-        groupid: params.groupid ? params.groupid : null
-      }
-    })
-
-    if (donations.status === 200 && donations.data.ret === 0) {
-      commit('set', {
-        target: Math.round(parseInt(donations.data.donations.target)),
-        raised: Math.round(parseInt(donations.data.donations.raised))
-      })
-    }
+    commit('set', await this.$api.donations.fetch(params.groupid))
   }
 }

--- a/store/group.js
+++ b/store/group.js
@@ -71,24 +71,10 @@ export const getters = {
 
 export const actions = {
   async list({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/groups', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('setList', res.data.groups)
-    }
+    commit('setList', await this.$api.group.list(params))
   },
 
-  async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/group', {
-      params: {
-        id: params.id
-      }
-    })
-
-    if (res.status === 200) {
-      commit('add', res.data.group)
-    }
+  async fetch({ commit }, { id }) {
+    commit('add', await this.$api.group.fetch(id))
   }
 }

--- a/store/invitations.js
+++ b/store/invitations.js
@@ -44,64 +44,23 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/invitation', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit(
-        'setList',
-        res.data.invitation ? [res.data.invitation] : res.data.invitations
-      )
-    }
+    const { invitation, invitations } = await this.$api.invitation.fetch(params)
+    commit('setList', invitation ? [invitation] : invitations)
   },
 
-  async delete({ commit, getters, dispatch }, params) {
-    await this.$axios.post(
-      process.env.API + '/invitation',
-      {
-        id: params.id
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
+  async delete({ commit, getters, dispatch }, { id }) {
+    await this.$api.invitation.del(id)
     await dispatch('fetch')
   },
 
   async add({ commit, getters, dispatch }, params) {
-    let id = null
-    const ret = await this.$axios.post(
-      process.env.API + '/invitation',
-      params,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PUT'
-        }
-      }
-    )
-
-    if (ret.status === 200) {
-      await dispatch('fetch', {
-        id: ret.data.id
-      })
-
-      id = ret.data.id
-    }
-
+    const id = await this.$api.invitation.add(params)
+    await dispatch('fetch', { id })
     return id
   },
 
   async edit({ commit, getters, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/invitation', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PATCH'
-      }
-    })
-
+    await this.$api.invitation.save(params)
     await dispatch('fetch', {
       id: params.id
     })

--- a/store/jobs.js
+++ b/store/jobs.js
@@ -27,13 +27,7 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get('/adview.php', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('setList', res.data.data)
-    }
+    commit('setList', await this.$api.job.fetch(params))
   },
 
   clear({ commit }) {

--- a/store/messages.js
+++ b/store/messages.js
@@ -105,43 +105,20 @@ export const actions = {
   },
 
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/message', {
-      params: params
-    })
-
-    commit('add', res.data.message)
+    const { message } = await this.$api.message.fetch(params)
+    commit('add', message)
   },
 
   async update({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(process.env.API + '/message', params)
-
-    console.log('Update returned', ret)
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      console.log('Fetch back')
-      await dispatch('fetch', {
-        id: params.id
-      })
-    }
-
-    return ret
+    const data = await this.$api.message.update(params)
+    await dispatch('fetch', { id: params.id })
+    return data
   },
 
   async patch({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(process.env.API + '/message', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PATCH'
-      }
-    })
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: params.id
-      })
-    }
-
-    return ret
+    const data = await this.$api.message.save(params)
+    await dispatch('fetch', { id: params.id })
+    return data
   },
 
   async promise({ dispatch }, params) {

--- a/store/messages.js
+++ b/store/messages.js
@@ -94,14 +94,9 @@ export const actions = {
       params.context = state.context
     }
 
-    const res = await this.$axios.get(process.env.API + '/messages', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('addAll', res.data.messages)
-      commit('setContext', res.data.context)
-    }
+    const { messages, context } = await this.$api.message.fetchMessages(params)
+    commit('addAll', messages)
+    commit('setContext', context)
   },
 
   async fetch({ commit }, params) {

--- a/store/noticeboards.js
+++ b/store/noticeboards.js
@@ -44,58 +44,25 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/noticeboard', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit(
-        'setList',
-        res.data.noticeboard ? [res.data.noticeboard] : res.data.noticeboards
-      )
-    }
+    const { noticeboard, noticeboards } = await this.$api.noticeboard.fetch(
+      params
+    )
+    commit('setList', noticeboard ? [noticeboard] : noticeboards)
   },
 
-  async delete({ commit, getters, dispatch }, params) {
-    await this.$axios.post(
-      process.env.API + '/noticeboard',
-      {
-        id: params.id
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
+  async delete({ commit, getters, dispatch }, { id }) {
+    await this.$api.noticeboard.del(id)
     await dispatch('fetch')
   },
 
   async add({ commit, getters, dispatch }, params) {
-    let id = null
-    const ret = await this.$axios.post(process.env.API + '/noticeboard', params)
-
-    if (ret.status === 200 && ret.data.id) {
-      await dispatch('fetch', {
-        id: ret.data.id
-      })
-
-      id = ret.data.id
-    }
-
+    const id = await this.$api.noticeboard.add(params)
+    await dispatch('fetch', { id })
     return id
   },
 
   async edit({ commit, getters, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/noticeboard', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PATCH'
-      }
-    })
-
-    await dispatch('fetch', {
-      id: params.id
-    })
+    await this.$api.noticeboard.save(params)
+    await dispatch('fetch', { id: params.id })
   }
 }

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -110,22 +110,14 @@ export const actions = {
     })
   },
 
-  async seen({ commit, dispatch }, params) {
-    commit('seen', params.id)
-
-    await this.$axios.post(process.env.API + '/notification', {
-      id: params.id,
-      action: 'Seen'
-    })
-
+  async seen({ commit, dispatch }, { id }) {
+    commit('seen', id)
+    await this.$api.notification.seen(id)
     await dispatch('count')
   },
 
-  async allSeen({ commit, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/notification', {
-      action: 'AllSeen'
-    })
-
+  async allSeen({ dispatch }) {
+    await this.$api.notification.allSeen()
     await dispatch('count')
   }
 }

--- a/store/schedule.js
+++ b/store/schedule.js
@@ -1,5 +1,5 @@
 export const state = () => ({
-  scheduke: {}
+  schedule: {}
 })
 
 export const mutations = {
@@ -16,25 +16,11 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/schedule', {
-      params: params
-    })
-
-    if (res.status === 200 && res.data.ret === 0) {
-      commit('set', res.data.schedule)
-    }
+    commit('set', await this.$api.schedule.fetch(params))
   },
 
   async update({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(process.env.API + '/schedule', params)
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        userid: params.userid
-      })
-    }
-
-    return ret
+    await this.$api.schedule.update(params)
+    await dispatch('fetch', { userid: params.userid })
   }
 }

--- a/store/searches.js
+++ b/store/searches.js
@@ -44,28 +44,11 @@ export const getters = {
 
 export const actions = {
   async fetchList({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/usersearch', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('setList', res.data.usersearches)
-    }
+    commit('setList', await this.$api.usersearch.list(params))
   },
 
-  async delete({ commit, getters, dispatch }, params) {
-    await this.$axios.post(
-      process.env.API + '/usersearch',
-      {
-        id: params.id
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
+  async delete({ commit, getters, dispatch }, { id }) {
+    await this.$api.usersearch.del(id)
     await dispatch('fetchList')
   }
 }

--- a/store/stats.js
+++ b/store/stats.js
@@ -36,25 +36,11 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/dashboard', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      commit('set', res.data.dashboard)
-    }
+    commit('set', await this.$api.dashboard.fetch(params))
   },
 
   async fetchHeatmap({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/dashboard', {
-      params: {
-        heatmap: true
-      }
-    })
-
-    if (res.status === 200) {
-      commit('setHeatmap', res.data.heatmap)
-    }
+    commit('setHeatmap', await this.$api.dashboard.fetchHeatmap())
   },
 
   clear({ commit }) {

--- a/store/stories.js
+++ b/store/stories.js
@@ -48,16 +48,11 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/stories', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      if (params.id) {
-        commit('add', res.data.story)
-      } else {
-        commit('setList', res.data.stories)
-      }
+    const { story, stories } = await this.$api.stories.fetch(params)
+    if (params.id) {
+      commit('add', story)
+    } else {
+      commit('setList', stories)
     }
   },
 
@@ -65,37 +60,17 @@ export const actions = {
     commit('clear')
   },
 
-  async add({ commit }, params) {
-    const res = await this.$axios.post(process.env.API + '/stories', params, {
-      headers: {
-        'X-HTTP-Method-Override': 'PUT'
-      }
-    })
-
-    let id = null
-
-    if (res.status === 200 && res.data.ret === 0) {
-      id = res.data.id
-    }
-
-    return id
+  add({ commit }, params) {
+    return this.$api.stories.add(params)
   },
 
   async love({ commit, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/stories', {
-      id: params.id,
-      action: 'Like'
-    })
-
+    await this.$api.stories.love(params.id)
     await dispatch('fetch', params)
   },
 
   async unlove({ commit, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/stories', {
-      id: params.id,
-      action: 'Unlike'
-    })
-
+    await this.$api.stories.unlove(params.id)
     await dispatch('fetch', params)
   }
 }

--- a/store/team.js
+++ b/store/team.js
@@ -22,14 +22,9 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const res = await this.$axios.get(process.env.API + '/team', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      console.log('Got', res.data.team)
-      commit('set', res.data.team)
-    }
+    const team = await this.$api.team.fetch(params)
+    console.log('Got', team)
+    commit('set', team)
   },
 
   clear({ commit }) {

--- a/store/user.js
+++ b/store/user.js
@@ -52,26 +52,12 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    const rsp = await this.$axios.get(process.env.API + '/user', {
-      params: params
-    })
-
-    if (rsp.status === 200 && rsp.data.ret === 0) {
-      commit('add', rsp.data.user)
-    }
+    commit('add', await this.$api.user.fetch(params))
   },
 
-  async rate({ commit, dispatch }, params) {
-    await this.$axios.post(process.env.API + '/user', {
-      action: 'Rate',
-      ratee: params.id,
-      rating: params.rating
-    })
-
+  async rate({ commit, dispatch }, { id, rating }) {
+    await this.$api.user.rate(id, rating)
     // Fetch the user back into the store to update any ratings elsewhere
-    await dispatch('fetch', {
-      id: params.id,
-      info: true
-    })
+    await dispatch('fetch', { id, info: true })
   }
 }

--- a/store/volunteerops.js
+++ b/store/volunteerops.js
@@ -139,20 +139,16 @@ export const actions = {
       params.systemwide = true
     }
 
-    const res = await this.$axios.get(process.env.API + '/volunteering', {
-      params: params
-    })
-
-    if (res.status === 200) {
-      if (params && params.id) {
-        commit('addAll', [res.data.volunteering])
-      } else {
-        commit('addAll', res.data.volunteerings)
-
-        commit('setContext', {
-          ctx: res.data.context
-        })
-      }
+    const {
+      volunteering,
+      volunteerings,
+      context
+    } = await this.$api.volunteering.fetch(params)
+    if (params && params.id) {
+      commit('addAll', [volunteering])
+    } else {
+      commit('addAll', volunteerings)
+      commit('setContext', { ctx: context })
     }
   },
   clear({ commit }) {
@@ -162,179 +158,49 @@ export const actions = {
 
     commit('setList', [])
   },
-  async save({ commit, dispatch }, event) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      event,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PATCH'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: event.id
-      })
-    }
-
-    return ret
+  async save({ commit, dispatch }, data) {
+    await this.$api.volunteering.save(data)
+    // Fetch back to update store and thereby components
+    await dispatch('fetch', { id: data.id })
   },
-  async add({ commit, dispatch }, event) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      event,
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'POST'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: ret.data.id
-      })
-    }
-
-    return ret.data.id
+  async add({ commit, dispatch }, data) {
+    const id = await this.$api.volunteering.add(data)
+    // Fetch back to update store and thereby components
+    await dispatch('fetch', { id })
+    return id
   },
-  async delete({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      {
-        id: params.id
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'DELETE'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      commit('delete', {
-        id: params.id
-      })
-    }
-
-    return ret
+  async delete({ commit, dispatch }, { id }) {
+    await this.$api.volunteering.del(id)
+    commit('delete', { id })
   },
-  async addGroup({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      {
-        id: params.id,
-        action: 'AddGroup',
-        groupid: params.groupid
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PATCH'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: params.id
-      })
-    }
-
-    return ret
+  async addGroup({ commit, dispatch }, { id, groupid }) {
+    await this.$api.volunteering.addGroup(id, groupid)
+    // Fetch back to update store and thereby components
+    await dispatch('fetch', { id })
   },
 
-  async removeGroup({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      {
-        id: params.id,
-        action: 'RemoveGroup',
-        groupid: params.groupid
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PATCH'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: params.id
-      })
-    }
-
-    return ret
+  async removeGroup({ commit, dispatch }, { id, groupid }) {
+    await this.$api.volunteering.removeGroup(id, groupid)
+    // Fetch back to update store and thereby components
+    await dispatch('fetch', { id })
   },
 
-  async setPhoto({ commit, dispatch }, params) {
-    const ret = await this.$axios.post(
-      process.env.API + '/volunteering',
-      {
-        id: params.id,
-        action: 'SetPhoto',
-        photoid: params.photoid
-      },
-      {
-        headers: {
-          'X-HTTP-Method-Override': 'PATCH'
-        }
-      }
-    )
-
-    if (ret.status === 200 && ret.data.ret === 0) {
-      // Fetch back to update store and thereby components
-      await dispatch('fetch', {
-        id: params.id
-      })
-    }
-
-    return ret
+  async setPhoto({ commit, dispatch }, { id, photoid }) {
+    await this.$api.volunteering.setPhoto(id, photoid)
+    // Fetch back to update store and thereby components
+    await dispatch('fetch', { id })
   },
 
   async setDates({ commit, dispatch }, params) {
     const promises = []
 
     for (const date of params.olddates) {
-      promises.push(
-        this.$axios.post(
-          process.env.API + '/volunteering',
-          {
-            id: params.id,
-            action: 'RemoveDate',
-            dateid: date.id
-          },
-          {
-            headers: {
-              'X-HTTP-Method-Override': 'PATCH'
-            }
-          }
-        )
-      )
+      promises.push(this.$api.volunteering.removeDate(params.id, date.id))
     }
 
     for (const date of params.newdates) {
       promises.push(
-        this.$axios.post(
-          process.env.API + '/volunteering',
-          {
-            id: params.id,
-            action: 'AddDate',
-            start: date.start,
-            end: date.end
-          },
-          {
-            headers: {
-              'X-HTTP-Method-Override': 'PATCH'
-            }
-          }
-        )
+        this.$api.volunteering.addDate(params.id, date.start, date.end)
       )
     }
 


### PR DESCRIPTION
For discussion :)

Adds an API layer, to clean up lots of axios request configuration options in the vuex actions.

It implements just `/session` and `/communityevent` API endpoints.

It uses es6 classes, which I would normally avoid, _but_ I wanted a good developer experience, which means autocomplete in editors working. This is actually tricky using nuxt plugins, as you end up making it available as `this.$api` ... and the typing information is not clear.

The _normal_ way to me would be to implement in such a way that you can do `import api from '@/api'` - _but_ axios is only available through the nuxt system, hence needing to implement the API this way too.

In general I'm not such a big fan of es6 classes, in this case, for this reason, maybe it's nice. My first implementation was just as plain objects, but then my IDE just shows me a wiggly line under `this.$api` and offers no completion options.

The mysterious `index.d.ts` enables intellij to have this type information, but I kind of hacked that file together quite ignorantly. I don't know if that would work in other editors too (e.g. vscode).

So, I put this up for initial discussion.
