### PR TITLE
Align the mark all read button to the right

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -61,9 +61,8 @@
                   Notifications
                 </div>
               </template>
-              <b-dropdown-item>
+              <b-dropdown-item class="text-right">
                 <b-btn variant="white" size="sm" @click="markAllRead">
-                  <!--                  TODO DESIGN Align to right; float right breaks divider-->
                   Mark all as read
                 </b-btn>
               </b-dropdown-item>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,7 @@
               </template>
               <b-dropdown-item class="text-right">
                 <b-btn variant="white" size="sm" @click="markAllRead">
-                  Mark all as read
+                  Mark all read
                 </b-btn>
               </b-dropdown-item>
               <b-dropdown-divider />


### PR DESCRIPTION
Sort out one of the TODOs.

At the moment the chats have the button "Mark all read" and the notifcations have the button "Mark all as read".  Should these be the same for consistency?