### PR TITLE
Remove any duplicates from the notification list

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -68,7 +68,6 @@
               </b-dropdown-item>
               <b-dropdown-divider />
               <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad">
-                <!--                TODO We're getting duplicate key errors here - click on notifications, close, click again.  Why?-->
                 <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
               </b-dropdown-item>
               <infinite-loading :distance="distance" @infinite="loadMore">

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import union from 'lodash/union'
+import uniqWith from 'lodash/uniqWith'
 import twem from '~/assets/js/twem'
 
 export const state = () => ({
@@ -9,6 +10,10 @@ export const state = () => ({
   context: null,
   count: 0
 })
+
+function compareNotificationIDs(x, y) {
+  return x.id === y.id
+}
 
 export const mutations = {
   add(state, notifications) {
@@ -23,7 +28,10 @@ export const mutations = {
             .trim()
         }
       }
-      state.list = union(state.list, notifications)
+      state.list = uniqWith(
+        union(state.list, notifications),
+        compareNotificationIDs
+      )
     }
   },
 


### PR DESCRIPTION
This PR deals with the TODO in default.vue regarding the Vue warning about duplicates in the notifications list.

The duplicates in default.vue notifications were coming from the store.  Each time the 'list' store action was called it was calling the 'add' mutation.  The lodash 'union' method combined the old and new notification data together.  Union only removes duplicate on primitive values and so the duplicate objects weren't being removed.  I've added an comparator function in to compare the IDs.

You might want to take a proper look at this solution as I'm not that familiar with the way the store is being used with the axios calls and when the data is refreshed. e.g. why don't we clear the list every time?
