### PR TITLE
Remove the footer duplication and move into a component

### DIFF
--- a/components/MainFooter.vue
+++ b/components/MainFooter.vue
@@ -1,0 +1,86 @@
+<template>
+  <footer class="footer mt-2 mb-2">
+    <div class="d-flex flex-column">
+      <ul class="d-flex flex-column flex-md-row justify-content-between list-unstyled p-0 ml-2 mr-2">
+        <li>
+          <nuxt-link to="/about" class="menu__link">
+            <v-icon name="info-circle" class="link__icon" />
+            About
+          </nuxt-link>
+        </li>
+        <li>
+          <nuxt-link to="/terms" class="menu__link">
+            <v-icon name="book-open" class="link__icon" />
+            Terms
+          </nuxt-link>
+        </li>
+        <li>
+          <nuxt-link to="/privacy" class="menu__link">
+            <v-icon name="lock" class="link__icon" />
+            Privacy
+          </nuxt-link>
+        </li>
+        <li>
+          <nuxt-link to="/disclaimer" class="menu__link">
+            <v-icon name="gavel" class="link__icon" />
+            Disclaimer
+          </nuxt-link>
+        </li>
+        <li>
+          <nuxt-link to="/donate" class="menu__link">
+            <v-icon name="hand-holding-heart" class="link__icon" />
+            Donate
+          </nuxt-link>
+        </li>
+        <li>
+          <nuxt-link to="/contact" class="menu__link">
+            <v-icon name="envelope" class="link__icon" />
+            Contact
+          </nuxt-link>
+        </li>
+      </ul>
+
+      <div class="text-muted">
+        Freegle is registered as a charity with HMRC (ref. XT32865).
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script>
+export default {
+  name: 'MainFooter'
+}
+</script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/mixins/_breakpoints';
+
+.footer {
+  max-width: map-get($grid-breakpoints, 'md');
+  margin: 0 auto;
+}
+
+@include media-breakpoint-up(md) {
+  .menu__link {
+    border: 1px $color-black solid;
+    border-radius: 0.25rem;
+    background-color: $color-white;
+    padding: 0.375rem 0.75rem;
+    color: $color-black;
+  }
+}
+
+.link__icon {
+  display: none;
+}
+
+@include media-breakpoint-up(md) {
+  .link__icon {
+    display: inline-block;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -91,61 +91,7 @@
         </b-row>
       </b-col>
     </b-row>
-    <footer>
-      <b-row class="m-0 mt-2">
-        <b-col cols="12" lg="6" offset-lg="3">
-          <div class="flex justify-content-between d-none d-sm-block">
-            <b-btn class="mb-2" variant="white" to="/about">
-              <v-icon name="info-circle" /> About
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/terms">
-              <v-icon name="book-open" /> Terms
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/privacy">
-              <v-icon name="lock" /> Privacy
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/disclaimer">
-              <v-icon name="gavel" /> Disclaimer
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/donate">
-              <v-icon name="hand-holding-heart" /> Donate
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/contact">
-              <v-icon name="envelope" /> Contact
-            </b-btn>
-            <b-btn class="mb-2" variant="white" to="/unsubscribe">
-              <v-icon name="trash-alt" /> Unsubscribe
-            </b-btn>
-          </div>
-          <div class="flex flex-wrap justify-content-between mb-2 d-block d-sm-none">
-            <nuxt-link to="/about">
-              About
-            </nuxt-link>
-            <nuxt-link to="/terms">
-              Terms
-            </nuxt-link>
-            <nuxt-link to="/privacy">
-              Privacy
-            </nuxt-link>
-            <nuxt-link to="/disclaimer">
-              Disclaimer
-            </nuxt-link>
-            <nuxt-link to="/donate">
-              Donate
-            </nuxt-link>
-            <nuxt-link to="/contact">
-              Contact
-            </nuxt-link>
-            <nuxt-link to="/unsubscribe">
-              Unsubscribe
-            </nuxt-link>
-          </div>
-          <span class="text-muted">
-            Freegle is registered as a charity with HMRC (ref. XT32865).
-          </span>
-        </b-col>
-      </b-row>
-    </footer>
+    <main-footer />
   </div>
 </template>
 
@@ -159,24 +105,17 @@
 .half-pad-col-left {
   padding-left: 7.5px;
 }
-
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 60px;
-  line-height: 60px;
-  background-color: $color-gray--lighter;
-}
 </style>
 
 <script>
 const StoriesLanding = () => import('~/components/StoriesLanding.vue')
+const MainFooter = () => import('~/components/MainFooter.vue')
 // TODO That thing where you prompt people on mobile to install the app.
 
 export default {
   components: {
-    StoriesLanding
+    StoriesLanding,
+    MainFooter
   },
 
   data: function() {


### PR DESCRIPTION
The footer in index had the options duplicated - one for desktop and one for mobile.  I've consolidated these into a single list which display differently at different breakpoints.

NB: I'm using the bootstrap functions to get the breakpoints rather than hardcoding the values in here.