### PR TITLE
A few api changes

### DIFF
--- a/api/BaseAPI.js
+++ b/api/BaseAPI.js
@@ -69,10 +69,6 @@ export default class BaseAPI {
     return this.$postOverride('PUT', path, data)
   }
 
-  $realPut(path, data) {
-    return this.$request('PUT', path, { data })
-  }
-
   $patch(path, data) {
     return this.$postOverride('PATCH', path, data)
   }

--- a/api/JobAPI.js
+++ b/api/JobAPI.js
@@ -1,19 +1,24 @@
 import { APIError } from './BaseAPI'
-import BaseAPI from '@/api/BaseAPI'
 
-export default class JobAPI extends BaseAPI {
+export default class JobAPI {
+  constructor({ $axios }) {
+    this.$axios = $axios
+  }
+
   async fetch(params) {
     // Note that the server side proxy we use to bypass CORS and get the jobs is not part of the API and therefore we
-    // don't use the usual API plugin.
-    const { data } = await this.$axios.get('/adview.php', params)
-
+    // don't use the usual API methods.
+    const path = '/adview.php'
+    const { status, data } = await this.$axios.get(path, { params })
     if (data && data.data) {
       return data.data
     } else {
       throw new APIError(
         {
           request: {
-            params: params
+            method: 'GET',
+            path,
+            params
           },
           response: {
             status,

--- a/api/MessageAPI.js
+++ b/api/MessageAPI.js
@@ -25,8 +25,7 @@ export default class MessageAPI extends BaseAPI {
     return this.$del('/message', { id })
   }
 
-  // TODO: work out if this is actually needed like this...
   put(data) {
-    return this.$realPut('/message', data)
+    return this.$put('/message', data)
   }
 }

--- a/store/jobs.js
+++ b/store/jobs.js
@@ -27,12 +27,7 @@ export const getters = {
 
 export const actions = {
   async fetch({ commit }, params) {
-    try {
-      commit('setList', await this.$api.job.fetch(params))
-    } catch (e) {
-      // If the API call fails, then just don't change the store.
-      console.error('Jobs API failed', e)
-    }
+    commit('setList', await this.$api.job.fetch(params))
   },
 
   clear({ commit }) {


### PR DESCRIPTION
For the JobAPI:
- need to pass in params in as { params } to axios calls
- get missing `status` value to use in case of error
- add extra data in APIError to match the BaseAPI style
- remove redundant try/catch in action
- don't inherit from BaseAPI (as it doesn't use anything from there)

.. I also removed the `$realPut` so it _always_ uses method overide approach now.