### PR TITLE
Add form validation

### DIFF
--- a/assets/css/_color-vars.scss
+++ b/assets/css/_color-vars.scss
@@ -39,6 +39,7 @@ $color-yellow-2: #FFEEBA;
 $color-yellow-3: #856404;
 
 $color-red: #FF0000;
+$color-danger: #dc3545; // from bootstrap _variables
 
 $color-white: #FFF;
 $color-black: #000;

--- a/assets/css/_color-vars.scss
+++ b/assets/css/_color-vars.scss
@@ -39,7 +39,6 @@ $color-yellow-2: #FFEEBA;
 $color-yellow-3: #856404;
 
 $color-red: #FF0000;
-$color-danger: #dc3545; // from bootstrap _variables
 
 $color-white: #FFF;
 $color-black: #000;

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -100,6 +100,7 @@
         <b-row>
           <b-col cols="12" md="6">
             <b-form-group
+              ref="groupid"
               label="For which community?"
               :state="validationEnabled ? !$v.groupid.$invalid : null"
             >
@@ -110,6 +111,7 @@
             </b-form-group>
             <b-form-group
               v-if="enabled"
+              ref="eventEdit__title"
               label="What's the event's name?"
               label-for="title"
               :state="validationEnabled ? !$v.eventEdit.title.$invalid : null"
@@ -175,6 +177,7 @@
             </b-col>
           </b-row>
           <b-form-group
+            ref="eventEdit__description"
             label="What is it?"
             label-for="description"
             :state="validationEnabled ? !$v.eventEdit.description.$invalid : null"
@@ -195,6 +198,7 @@
             />
           </b-form-group>
           <b-form-group
+            ref="eventEdit__location"
             label="Where is it?"
             label-for="location"
             :state="validationEnabled ? !$v.eventEdit.location.$invalid : null"
@@ -212,6 +216,7 @@
             />
           </b-form-group>
           <b-form-group
+            ref="eventEdit__dates"
             label="When is it?"
             :state="validationEnabled ? !$v.eventEdit.dates.$invalid : null"
           >
@@ -222,6 +227,7 @@
             <StartEndCollection v-if="eventEdit.dates" v-model="eventEdit.dates" add-date-if-empty />
           </b-form-group>
           <b-form-group
+            ref="eventEdit__contactname"
             label="Contact name:"
             label-for="contactname"
             :state="eventEdit.contactname && validationEnabled ? !$v.eventEdit.contactname.$invalid : null"
@@ -357,7 +363,6 @@
 // TODO NS Don't allow submission before image upload complete.
 // TODO Wherever we have b-img (throughout the site, not just here) we should have @brokenImage.  Bet we don't.
 // TODO NS Set date to start at 9am rather than midnight.  Default end date to later than start date.
-import Vue from 'vue'
 import { required, maxLength } from 'vuelidate/lib/validators'
 import cloneDeep from 'lodash.clonedeep'
 import { validationMixin } from 'vuelidate'
@@ -369,15 +374,6 @@ const GroupRememberSelect = () => import('~/components/GroupRememberSelect')
 const OurFilePond = () => import('~/components/OurFilePond')
 const StartEndCollection = () => import('~/components/StartEndCollection')
 const NoticeMessage = () => import('~/components/NoticeMessage')
-
-// TODO NS move into utilities somewhere
-function nextTicks(n, fn) {
-  if (n === 0) {
-    fn()
-  } else {
-    Vue.nextTick(() => nextTicks(n - 1, fn))
-  }
-}
 
 function initialEvent() {
   return {
@@ -484,9 +480,7 @@ export default {
     async saveIt() {
       this.$v.$touch()
       if (this.$v.$anyError) {
-        // It takes a few cycles to actually render the errors...
-        // TODO NS this is a bit hacky, I think a better way is to use refs to find the elements to focus
-        nextTicks(4, () => this.validationFocusFirstError())
+        this.validationFocusFirstError()
         return
       }
 

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -396,8 +396,8 @@ export default {
       this.hide()
     },
     async saveIt() {
-      this.$v.form.$touch()
-      if (this.$v.form.$anyError) {
+      this.$v.event.$touch()
+      if (this.$v.event.$anyError) {
         return
       }
 

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -105,13 +105,17 @@
             <label v-if="enabled" for="title">
               What's the event's name?
             </label>
-            <b-form-input
+            <validating-form-input
               v-if="enabled"
               id="title"
               v-model="event.title"
               type="text"
-              maxlength="80"
               placeholder="Give the event a short title"
+              :validation="$v.event.title"
+              :validation-messages="{
+                required: 'Title is required',
+                maxLength: ({ max }) => `Max length is ${max}`
+              }"
             />
           </b-col>
           <b-col v-if="enabled" cols="12" md="6">
@@ -163,7 +167,7 @@
           <label for="description">
             What is it?
           </label>
-          <b-textarea
+          <validating-textarea
             id="description"
             v-model="event.description"
             rows="5"
@@ -171,11 +175,24 @@
             spellcheck="true"
             placeholder="Let people know what the event is - why they should come, what to expect, and any admission charge or fee (we only approve free or cheap events)."
             class="mt-2"
+            :validation="$v.event.description"
+            :validation-messages="{
+              required: 'Description is required'
+            }"
           />
           <label for="location">
             Where is it?
           </label>
-          <b-form-input id="location" v-model="event.location" type="text" maxlength="80" placeholder="Where is it being held?  Add a postcode to make sure people can find you!" />
+          <validating-form-input
+            id="location"
+            v-model="event.location"
+            type="text"
+            placeholder="Where is it being held? Add a postcode to make sure people can find you!"
+            :validation="$v.event.location"
+            :validation-messages="{
+              required: 'Location is required'
+            }"
+          />
           <label>
             When is it?
           </label>
@@ -271,8 +288,12 @@ label {
 // TODO NS Don't allow submission before image upload complete.
 // TODO Wherever we have b-img (throughout the site, not just here) we should have @brokenImage.  Bet we don't.
 // TODO NS Set date to start at 9am rather than midnight.  Default end date to later than start date.
+import { validationMixin } from 'vuelidate'
+import { required, maxLength } from 'vuelidate/lib/validators'
 import cloneDeep from 'lodash.clonedeep'
 import twem from '~/assets/js/twem'
+import ValidatingFormInput from '@/components/ValidatingFormInput'
+import ValidatingTextarea from '@/components/ValidatingTextarea'
 const GroupRememberSelect = () => import('~/components/GroupRememberSelect')
 const OurFilePond = () => import('~/components/OurFilePond')
 const StartEndCollection = () => import('~/components/StartEndCollection')
@@ -280,11 +301,14 @@ const NoticeMessage = () => import('~/components/NoticeMessage')
 
 export default {
   components: {
+    ValidatingFormInput,
+    ValidatingTextarea,
     GroupRememberSelect,
     OurFilePond,
     StartEndCollection,
     NoticeMessage
   },
+  mixins: [validationMixin],
   props: {
     event: {
       type: Object,
@@ -372,6 +396,11 @@ export default {
       this.hide()
     },
     async saveIt() {
+      this.$v.form.$touch()
+      if (this.$v.form.$anyError) {
+        return
+      }
+
       // TODO NS Validation.
       this.saving = true
 
@@ -501,6 +530,20 @@ export default {
     },
     rotateRight() {
       this.rotate(-90)
+    }
+  },
+  validations: {
+    event: {
+      title: {
+        required,
+        maxLength: maxLength(80)
+      },
+      description: {
+        required
+      },
+      location: {
+        required
+      }
     }
   }
 }

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -312,6 +312,8 @@
 
 <style scoped lang="scss">
 @import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
 
 .field {
   font-weight: bold;
@@ -330,7 +332,7 @@
 
 ::v-deep .is-invalid label,
 ::v-deep .is-invalid .col-form-label {
-  color: $color-danger;
+  color: $form-feedback-invalid-color;
 }
 
 ::v-deep .form-group.is-invalid .invalid-feedback {

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -354,7 +354,6 @@
 
 <script>
 // TODO DESIGN This layout is staid table nonsense.  Surely we can make it more appealing?
-// TODO NS Add some form validation using a plugin - see https://bootstrap-vue.js.org/docs/reference/validation/
 // TODO NS Don't allow submission before image upload complete.
 // TODO Wherever we have b-img (throughout the site, not just here) we should have @brokenImage.  Bet we don't.
 // TODO NS Set date to start at 9am rather than midnight.  Default end date to later than start date.
@@ -490,7 +489,6 @@ export default {
         return
       }
 
-      // TODO NS Validation.
       this.saving = true
 
       if (this.isExisting) {

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -518,10 +518,6 @@ export default {
         return
       }
 
-      console.log('WOULD have saved it', this.event)
-
-      // if (this.event !== 'a small brown dog') return
-
       // TODO NS Validation.
       this.saving = true
 

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -359,9 +359,10 @@
 // TODO Wherever we have b-img (throughout the site, not just here) we should have @brokenImage.  Bet we don't.
 // TODO NS Set date to start at 9am rather than midnight.  Default end date to later than start date.
 import Vue from 'vue'
-import { validationMixin } from 'vuelidate'
 import { required, maxLength } from 'vuelidate/lib/validators'
 import cloneDeep from 'lodash.clonedeep'
+import { validationMixin } from 'vuelidate'
+import validationHelpers from '@/mixins/validationHelpers'
 import twem from '~/assets/js/twem'
 import ValidatingFormInput from '@/components/ValidatingFormInput'
 import ValidatingTextarea from '@/components/ValidatingTextarea'
@@ -417,7 +418,7 @@ export default {
     StartEndCollection,
     NoticeMessage
   },
-  mixins: [validationMixin],
+  mixins: [validationMixin, validationHelpers],
   props: {
     event: {
       type: Object,
@@ -433,9 +434,6 @@ export default {
   computed: {
     isExisting() {
       return Boolean(this.event.id)
-    },
-    validationEnabled() {
-      return this.$v.eventEdit.$dirty
     },
     description() {
       let desc = this.eventEdit.description
@@ -484,28 +482,11 @@ export default {
       Object.assign(this, initialData.call(this))
       this.$v.$reset()
     },
-    focusFirstError() {
-      // We want to scroll to the form group, so the label is visible
-      const scrollToEl = this.$refs.form.querySelector('.is-invalid')
-      // ... but focus the first input field
-      const focusEl = this.$refs.form.querySelector(
-        'input.is-invalid, textarea.is-invalid'
-      )
-      if (scrollToEl) scrollToEl.scrollIntoView()
-      if (focusEl) {
-        if (!scrollToEl) {
-          // we can make do with scrolling to the input
-          focusEl.scrollIntoView()
-        }
-        focusEl.focus()
-      }
-      return scrollToEl || focusEl
-    },
     async saveIt() {
       this.$v.$touch()
       if (this.$v.$anyError) {
         // It takes a few cycles to actually render the errors...
-        nextTicks(4, () => this.focusFirstError())
+        nextTicks(4, () => this.validationFocusFirstError())
         return
       }
 

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -150,7 +150,7 @@
                   </v-icon>
                 </span>
               </div>
-              <b-img v-if="event.photo" thumbnail :src="eventEdit.photo.paththumb + '?' + cacheBust" />
+              <b-img v-if="eventEdit.photo" thumbnail :src="eventEdit.photo.paththumb + '?' + cacheBust" />
               <b-img v-else width="250" thumbnail src="~/static/placeholder.jpg" />
             </div>
           </b-col>

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -4,11 +4,11 @@
     v-model="showModal"
     size="lg"
     no-stacking
-    @hidden="resetData()"
+    @hidden="reset()"
   >
     <template slot="modal-header">
       <h4 v-if="editing">
-        <span v-if="event.id">
+        <span v-if="isExisting">
           Edit Event
         </span>
         <span v-else>
@@ -112,14 +112,14 @@
               v-if="enabled"
               label="What's the event's name?"
               label-for="title"
-              :state="validationEnabled ? !$v.event.title.$invalid : null"
+              :state="validationEnabled ? !$v.eventEdit.title.$invalid : null"
             >
               <validating-form-input
                 id="title"
-                v-model="event.title"
+                v-model="eventEdit.title"
                 type="text"
                 placeholder="Give the event a short title"
-                :validation="$v.event.title"
+                :validation="$v.eventEdit.title"
                 :validation-enabled="validationEnabled"
                 :validation-messages="{
                   required: 'Please add a title',
@@ -130,7 +130,7 @@
           </b-col>
           <b-col v-if="enabled" cols="12" md="6">
             <div class="float-right">
-              <div v-if="event.photo" class="container p-0">
+              <div v-if="eventEdit.photo" class="container p-0">
                 <span @click="rotateLeft">
                   <v-icon label="Rotate left" class="topleft clickme" title="Rotate left">
                     <v-icon name="circle" scale="2" />
@@ -150,7 +150,7 @@
                   </v-icon>
                 </span>
               </div>
-              <b-img v-if="event.photo" thumbnail :src="event.photo.paththumb + '?' + cacheBust" />
+              <b-img v-if="event.photo" thumbnail :src="eventEdit.photo.paththumb + '?' + cacheBust" />
               <b-img v-else width="250" thumbnail src="~/static/placeholder.jpg" />
             </div>
           </b-col>
@@ -177,17 +177,17 @@
           <b-form-group
             label="What is it?"
             label-for="description"
-            :state="validationEnabled ? !$v.event.description.$invalid : null"
+            :state="validationEnabled ? !$v.eventEdit.description.$invalid : null"
           >
             <validating-textarea
               id="description"
-              v-model="event.description"
+              v-model="eventEdit.description"
               rows="5"
               max-rows="8"
               spellcheck="true"
               placeholder="Let people know what the event is - why they should come, what to expect, and any admission charge or fee (we only approve free or cheap events)."
               class="mt-2"
-              :validation="$v.event.description"
+              :validation="$v.eventEdit.description"
               :validation-enabled="validationEnabled"
               :validation-messages="{
                 required: 'Please add a description'
@@ -197,14 +197,14 @@
           <b-form-group
             label="Where is it?"
             label-for="location"
-            :state="validationEnabled ? !$v.event.location.$invalid : null"
+            :state="validationEnabled ? !$v.eventEdit.location.$invalid : null"
           >
             <validating-form-input
               id="location"
-              v-model="event.location"
+              v-model="eventEdit.location"
               type="text"
               placeholder="Where is it being held? Add a postcode to make sure people can find you!"
-              :validation="$v.event.location"
+              :validation="$v.eventEdit.location"
               :validation-enabled="validationEnabled"
               :validation-messages="{
                 required: 'Please add a location'
@@ -213,26 +213,26 @@
           </b-form-group>
           <b-form-group
             label="When is it?"
-            :state="validationEnabled ? !$v.event.dates.$invalid : null"
+            :state="validationEnabled ? !$v.eventEdit.dates.$invalid : null"
           >
             <p>You can add multiple dates if the event occurs several times.</p>
             <b-form-invalid-feedback class="mb-3">
               Please add at least one date
             </b-form-invalid-feedback>
-            <StartEndCollection v-if="event.dates" v-model="event.dates" add-date-if-empty />
+            <StartEndCollection v-if="eventEdit.dates" v-model="eventEdit.dates" add-date-if-empty />
           </b-form-group>
           <b-form-group
             label="Contact name:"
             label-for="contactname"
-            :state="event.contactname && validationEnabled ? !$v.event.contactname.$invalid : null"
+            :state="eventEdit.contactname && validationEnabled ? !$v.eventEdit.contactname.$invalid : null"
           >
             <validating-form-input
               id="contactname"
-              v-model="event.contactname"
+              v-model="eventEdit.contactname"
               type="text"
               placeholder="Is there a contact person for anyone who wants to find out more? (Optional)"
-              :validation="$v.event.contactname"
-              :validation-enabled="event.contactname && validationEnabled"
+              :validation="$v.eventEdit.contactname"
+              :validation-enabled="eventEdit.contactname && validationEnabled"
               :validation-messages="{
                 maxLength: ({ max }) => `Max length is ${max}`
               }"
@@ -244,7 +244,7 @@
           >
             <b-form-input
               id="contactemail"
-              v-model="event.contactemail"
+              v-model="eventEdit.contactemail"
               type="email"
               placeholder="Can people reach you by email? (Optional)"
             />
@@ -255,7 +255,7 @@
           >
             <b-form-input
               id="contactphone"
-              v-model="event.contactphone"
+              v-model="eventEdit.contactphone"
               type="tel"
               placeholder="Can people reach you by phone? (Optional)"
             />
@@ -266,7 +266,7 @@
           >
             <b-form-input
               id="contacturl"
-              v-model="event.contacturl"
+              v-model="eventEdit.contacturl"
               type="tel"
               placeholder="Is there more information on the web? (Optional)"
             />
@@ -297,7 +297,7 @@
       <b-button v-if="editing" variant="success" class="float-right" @click="saveIt">
         <v-icon v-if="saving" name="sync" class="fa-spin" />
         <v-icon v-else name="save" />
-        <span v-if="event.id">Save Changes</span>
+        <span v-if="isExisting">Save Changes</span>
         <span v-else>Add Event</span>
       </b-button>
     </template>
@@ -398,12 +398,11 @@ function initialEvent() {
 
 function initialData() {
   return {
+    eventEdit: cloneDeep(this.event),
     showModal: false,
     editing: false,
     groupid: null,
     uploading: false,
-    oldphoto: null,
-    olddates: null,
     cacheBust: Date.now(),
     saving: false
   }
@@ -432,11 +431,14 @@ export default {
   },
   data: initialData,
   computed: {
+    isExisting() {
+      return Boolean(this.event.id)
+    },
     validationEnabled() {
-      return this.$v.event.$dirty
+      return this.$v.eventEdit.$dirty
     },
     description() {
-      let desc = this.event.description
+      let desc = this.eventEdit.description
       desc = desc ? twem.twem(this.$twemoji, desc) : ''
       desc = desc.trim()
       return desc
@@ -453,27 +455,19 @@ export default {
       }
 
       return ret
-    }
-  },
-  watch: {
-    showModal(val, oldVal) {
-      console.log('showModal', oldVal, '->', val)
+    },
+    shouldUpdatePhoto() {
+      const { photo: oldPhoto } = this.event
+      const { photo: newPhoto } = this.eventEdit
+      return newPhoto && (oldPhoto ? newPhoto.id !== oldPhoto.id : true)
     }
   },
   methods: {
     show() {
       this.editing = this.startEdit
       this.showModal = true
-
-      this.oldphoto =
-        this.event && this.event.photo ? this.event.photo.id : null
-      this.olddates =
-        this.event && this.event.dates && this.event.dates.length > 0
-          ? cloneDeep(this.event.dates)
-          : null
-
-      if (this.event.groups && this.event.groups.length > 0) {
-        this.groupid = this.event.groups[0].id
+      if (this.eventEdit.groups && this.eventEdit.groups.length > 0) {
+        this.groupid = this.eventEdit.groups[0].id
       }
     },
     hide() {
@@ -486,11 +480,8 @@ export default {
 
       this.hide()
     },
-    resetData() {
-      Object.assign(this, initialData())
-    },
-    resetEvent() {
-      Object.assign(this.event, initialEvent())
+    reset() {
+      Object.assign(this, initialData.call(this))
       this.$v.$reset()
     },
     focusFirstError() {
@@ -521,12 +512,13 @@ export default {
       // TODO NS Validation.
       this.saving = true
 
-      if (this.event.id) {
+      if (this.isExisting) {
+        const { id } = this.event
         // This is an edit.
-        if (this.event.photo && this.event.photo.id !== this.oldphoto) {
+        if (this.shouldUpdatePhoto) {
           await this.$store.dispatch('communityevents/setPhoto', {
-            id: this.event.id,
-            photoid: this.event.photo.id
+            id,
+            photoid: this.eventEdit.photo.id
           })
         }
 
@@ -536,57 +528,57 @@ export default {
         if (this.groupid !== oldgroupid) {
           // Save the new group, then remove the old group, so it won't get stranded.
           await this.$store.dispatch('communityevents/addGroup', {
-            id: this.event.id,
+            id,
             groupid: this.groupid
           })
 
           if (oldgroupid) {
             await this.$store.dispatch('communityevents/removeGroup', {
-              id: this.event.id,
+              id,
               groupid: oldgroupid
             })
           }
         }
 
         await this.$store.dispatch('communityevents/setDates', {
-          id: this.event.id,
-          olddates: this.olddates,
-          newdates: this.event.dates
+          id,
+          olddates: this.event.dates,
+          newdates: this.eventEdit.dates
         })
 
-        await this.$store.dispatch('communityevents/save', this.event)
+        await this.$store.dispatch('communityevents/save', this.eventEdit)
       } else {
         // This is an add.  First create it to get the id.
-        const dates = this.event.dates
-        const photoid = this.event.photo ? this.event.photo.id : null
+        const dates = this.eventEdit.dates
+        const photoid = this.eventEdit.photo ? this.eventEdit.photo.id : null
 
-        const eventid = await this.$store.dispatch(
+        const id = await this.$store.dispatch(
           'communityevents/add',
-          this.event
+          this.eventEdit
         )
 
         if (photoid) {
           await this.$store.dispatch('communityevents/setPhoto', {
-            id: eventid,
+            id,
             photoid: photoid
           })
         }
 
         // Save the group.
         await this.$store.dispatch('communityevents/addGroup', {
-          id: eventid,
+          id,
           groupid: this.groupid
         })
 
         await this.$store.dispatch('communityevents/setDates', {
-          id: eventid,
+          id,
           olddates: [],
           newdates: dates
         })
 
         // Fetch for good luck.
         await this.$store.dispatch('communityevents/fetch', {
-          id: eventid
+          id
         })
       }
 
@@ -599,7 +591,6 @@ export default {
       })
 
       this.hide()
-      this.resetEvent()
     },
     photoAdd() {
       // Flag that we're uploading.  This will trigger the render of the filepond instance and subsequently the
@@ -610,7 +601,7 @@ export default {
       // We have uploaded a photo.  Remove the filepond instance.
       this.uploading = false
 
-      this.event.photo = {
+      this.eventEdit.photo = {
         id: imageid,
         path: image,
         paththumb: imagethumb
@@ -622,19 +613,19 @@ export default {
         const title = p !== -1 ? ocr.substring(0, p) : null
         const desc = p !== -1 ? ocr.substring(p + 1) : ocr
 
-        if (!this.event.title) {
-          this.event.title = title
+        if (!this.eventEdit.title) {
+          this.eventEdit.title = title
         }
 
-        if (!this.event.description) {
-          this.event.description = desc
+        if (!this.eventEdit.description) {
+          this.eventEdit.description = desc
         }
       }
     },
     rotate(deg) {
       this.$axios
         .post(process.env.API + '/image', {
-          id: this.event.photo.id,
+          id: this.eventEdit.photo.id,
           rotate: deg,
           bust: Date.now(),
           communityevent: true
@@ -654,7 +645,7 @@ export default {
     groupid: {
       required
     },
-    event: {
+    eventEdit: {
       title: {
         required,
         maxLength: maxLength(80)

--- a/components/CommunityEventModal.vue
+++ b/components/CommunityEventModal.vue
@@ -485,6 +485,7 @@ export default {
       this.$v.$touch()
       if (this.$v.$anyError) {
         // It takes a few cycles to actually render the errors...
+        // TODO NS this is a bit hacky, I think a better way is to use refs to find the elements to focus
         nextTicks(4, () => this.validationFocusFirstError())
         return
       }
@@ -636,6 +637,7 @@ export default {
         required
       },
       dates: {
+        // TODO validate each entry is not more than 4 days in duration
         minLength: dates =>
           dates.filter(({ start, end }) => start && end).length > 0
       },

--- a/components/ValidatingFormInput.vue
+++ b/components/ValidatingFormInput.vue
@@ -15,10 +15,10 @@
 </template>
 
 <script>
-import validationHelpers from '@/mixins/validationHelpers'
+import validationFieldHelpers from '@/mixins/validationFieldHelpers'
 
 export default {
-  mixins: [validationHelpers],
+  mixins: [validationFieldHelpers],
   computed: {
     maxLength() {
       return this.validationTypes.includes('maxLength')

--- a/components/ValidatingFormInput.vue
+++ b/components/ValidatingFormInput.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <b-form-input
-      :state="validation.$dirty ? !validation.$error : null"
+      :state="validationState"
       :aria-describedby="feedbackId"
       :maxlength="maxLength"
       v-bind="$attrs"
       v-on="$listeners"
       @blur="validation.$touch"
     />
-    <b-form-invalid-feedback v-if="validation.$error" :id="feedbackId">
+    <b-form-invalid-feedback v-if="hasValidationError" :id="feedbackId">
       <span v-if="firstValidationError">{{ firstValidationError }}</span>
     </b-form-invalid-feedback>
   </div>

--- a/components/ValidatingFormInput.vue
+++ b/components/ValidatingFormInput.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <b-form-input
+      :state="validation.$dirty ? !validation.$error : null"
+      :aria-describedby="feedbackId"
+      :maxlength="maxLength"
+      v-bind="$attrs"
+      v-on="$listeners"
+      @blur="validation.$touch"
+    />
+    <b-form-invalid-feedback v-if="validation.$error" :id="feedbackId">
+      <span v-if="firstValidationError">{{ firstValidationError }}</span>
+    </b-form-invalid-feedback>
+  </div>
+</template>
+
+<script>
+import validationHelpers from '@/mixins/validationHelpers'
+
+export default {
+  mixins: [validationHelpers],
+  computed: {
+    maxLength() {
+      return this.validationTypes.includes('maxLength')
+        ? this.validation.$params.maxLength.max
+        : null
+    }
+  }
+}
+</script>

--- a/components/ValidatingTextarea.vue
+++ b/components/ValidatingTextarea.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <b-textarea
+      :state="validation.$dirty ? !validation.$error : null"
+      :aria-describedby="feedbackId"
+      v-bind="$attrs"
+      v-on="$listeners"
+      @blur="validation.$touch"
+    />
+    <b-form-invalid-feedback v-if="validation.$error" :id="feedbackId">
+      <span v-if="firstValidationError">{{ firstValidationError }}</span>
+    </b-form-invalid-feedback>
+  </div>
+</template>
+
+<script>
+import validationHelpers from '@/mixins/validationHelpers'
+
+export default {
+  mixins: [validationHelpers]
+}
+</script>

--- a/components/ValidatingTextarea.vue
+++ b/components/ValidatingTextarea.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <b-textarea
-      :state="validation.$dirty ? !validation.$error : null"
+      :state="validationState"
       :aria-describedby="feedbackId"
       v-bind="$attrs"
       v-on="$listeners"
       @blur="validation.$touch"
     />
-    <b-form-invalid-feedback v-if="validation.$error" :id="feedbackId">
+    <b-form-invalid-feedback v-if="hasValidationError" :id="feedbackId">
       <span v-if="firstValidationError">{{ firstValidationError }}</span>
     </b-form-invalid-feedback>
   </div>

--- a/components/ValidatingTextarea.vue
+++ b/components/ValidatingTextarea.vue
@@ -14,9 +14,9 @@
 </template>
 
 <script>
-import validationHelpers from '@/mixins/validationHelpers'
+import validationFieldHelpers from '@/mixins/validationFieldHelpers'
 
 export default {
-  mixins: [validationHelpers]
+  mixins: [validationFieldHelpers]
 }
 </script>

--- a/mixins/validationFieldHelpers.js
+++ b/mixins/validationFieldHelpers.js
@@ -43,7 +43,7 @@ export default {
   computed: {
     /**
      * The errors come with a nice element to show the error messages.
-     * It will use this as it's id
+     * It will use this as its id
      *
      * @returns {string}
      */
@@ -98,7 +98,7 @@ export default {
      * Returns the first error message if there are validation errors.
      * It's a bit overwhelming to show them all errors at once.
      * The order of how to show them if there are multiple errors
-     * is detirmined by the order returned by "validationTypes".
+     * is determined by the order returned by "validationTypes".
      *
      * The messages come from the "validationMessages" prop.
      *

--- a/mixins/validationFieldHelpers.js
+++ b/mixins/validationFieldHelpers.js
@@ -1,0 +1,117 @@
+/**
+ * These are helpers useful for our validation field helpers. The ones that wrap the bootstrap components.
+ */
+export default {
+  props: {
+    /**
+     * The vuelidate validation object for this field.
+     * Available under "$v.your.validated.field"
+     * e.g. "$v.event.title"
+     */
+    validation: {
+      type: Object,
+      required: true
+    },
+    /**
+     * We want to control whether to enable the validation to not
+     * overwhelm the user as they write.
+     */
+    validationEnabled: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * vuelidate does not help us with the messages to show, this lets us
+     * specify the error message for each associated validation type, e.g:
+     *
+     *   {
+     *     required: 'Please add a foo'
+     *   }
+     *
+     * If you pass in a function it will pass you the vuelidate config for that
+     * validation: e.g.
+     *
+     *   {
+     *     maxLength: ({ max }) => `Please make it less than ${max}`
+     *   }
+     */
+    validationMessages: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    /**
+     * The errors come with a nice element to show the error messages.
+     * It will use this as it's id
+     *
+     * @returns {string}
+     */
+    feedbackId() {
+      return this.$attrs.id + '-feedback'
+    },
+    /**
+     * All the available validation types on this field.
+     * e.g. ['required', 'maxLength']
+     *
+     * @returns {string[]}
+     */
+    validationTypes() {
+      return Object.keys(this.validation).filter(k => !/^$/.test(k))
+    },
+    /**
+     * All the validation types that have an error.
+     * e.g. ['required']
+     *
+     * @returns {string[]}
+     */
+    validationErrorTypes() {
+      return this.validationEnabled
+        ? this.validationTypes.filter(k => !this.validation[k])
+        : []
+    },
+    /**
+     * Is there at least one error?
+     *
+     * @returns {true|false}
+     */
+    hasValidationError() {
+      return this.validationEnabled && this.validation.$dirty
+        ? this.validation.$error
+        : false
+    },
+    /**
+     * Useful for putting in the bootstrap :state prop
+     *
+     *   true  -> valid
+     *   false -> invalid
+     *   null  -> not validated yet, neutral
+     *
+     * @returns {true|false|null}
+     */
+    validationState() {
+      return this.validationEnabled && this.validation.$dirty
+        ? !this.validation.$error
+        : null
+    },
+    /**
+     * Returns the first error message if there are validation errors.
+     * It's a bit overwhelming to show them all errors at once.
+     * The order of how to show them if there are multiple errors
+     * is detirmined by the order returned by "validationTypes".
+     *
+     * The messages come from the "validationMessages" prop.
+     *
+     * @returns {string|undefined}
+     */
+    firstValidationError() {
+      if (this.validationErrorTypes.length > 0) {
+        const type = this.validationErrorTypes[0]
+        const message = this.validationMessages[type]
+        return typeof message === 'function'
+          ? message(this.validation.$params[type])
+          : message
+      }
+    }
+  }
+}

--- a/mixins/validationHelpers.js
+++ b/mixins/validationHelpers.js
@@ -1,0 +1,31 @@
+export default {
+  props: {
+    validation: {
+      type: Object,
+      required: true
+    },
+    validationMessages: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    feedbackId() {
+      return this.$attrs.id + '-feedback'
+    },
+    validationTypes() {
+      return Object.keys(this.validation).filter(k => !/^$/.test(k))
+    },
+    validationErrors() {
+      return this.validationTypes.filter(k => !this.validation[k])
+    },
+    firstValidationError() {
+      const type = this.validationErrors[0]
+      if (!type) return
+      const message = this.validationMessages[type]
+      return typeof message === 'function'
+        ? message(this.validation.$params[type])
+        : message
+    }
+  }
+}

--- a/mixins/validationHelpers.js
+++ b/mixins/validationHelpers.js
@@ -1,31 +1,114 @@
 export default {
   props: {
+    /**
+     * The vuelidate validation object for this field.
+     * Available under "$v.your.validated.field"
+     * e.g. "$v.event.title"
+     */
     validation: {
       type: Object,
       required: true
     },
+    /**
+     * We want to control whether to enable the validation to not
+     * overwhelm the user as they write.
+     */
+    validationEnabled: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * vuelidate does not help us with the messages to show, this lets us
+     * specify the error message for each associated validation type, e.g:
+     *
+     *   {
+     *     required: 'Please add a foo'
+     *   }
+     *
+     * If you pass in a function it will pass you the vuelidate config for that
+     * validation: e.g.
+     *
+     *   {
+     *     maxLength: ({ max }) => `Please make it less than ${max}`
+     *   }
+     */
     validationMessages: {
       type: Object,
       required: true
     }
   },
   computed: {
+    /**
+     * The errors come with a nice element to show the error messages.
+     * It will use this as it's id
+     *
+     * @returns {string}
+     */
     feedbackId() {
       return this.$attrs.id + '-feedback'
     },
+    /**
+     * All the available validation types on this field.
+     * e.g. ['required', 'maxLength']
+     *
+     * @returns {string[]}
+     */
     validationTypes() {
       return Object.keys(this.validation).filter(k => !/^$/.test(k))
     },
-    validationErrors() {
-      return this.validationTypes.filter(k => !this.validation[k])
+    /**
+     * All the validation types that have an error.
+     * e.g. ['required']
+     *
+     * @returns {string[]}
+     */
+    validationErrorTypes() {
+      return this.validationEnabled
+        ? this.validationTypes.filter(k => !this.validation[k])
+        : []
     },
+    /**
+     * Is there at least one error?
+     *
+     * @returns {true|false}
+     */
+    hasValidationError() {
+      return this.validationEnabled && this.validation.$dirty
+        ? this.validation.$error
+        : false
+    },
+    /**
+     * Useful for putting in the bootstrap :state prop
+     *
+     *   true  -> valid
+     *   false -> invalid
+     *   null  -> not validated yet, neutral
+     *
+     * @returns {true|false|null}
+     */
+    validationState() {
+      return this.validationEnabled && this.validation.$dirty
+        ? !this.validation.$error
+        : null
+    },
+    /**
+     * Returns the first error message if there are validation errors.
+     * It's a bit overwhelming to show them all errors at once.
+     * The order of how to show them if there are multiple errors
+     * is detirmined by the order returned by "validationTypes".
+     *
+     * The messages come from the "validationMessages" prop.
+     *
+     * @returns {string|undefined}
+     */
     firstValidationError() {
-      const type = this.validationErrors[0]
-      if (!type) return
-      const message = this.validationMessages[type]
-      return typeof message === 'function'
-        ? message(this.validation.$params[type])
-        : message
+      if (this.validationErrorTypes.length > 0) {
+        const type = this.validationErrorTypes[0]
+        const message = this.validationMessages[type]
+        return typeof message === 'function'
+          ? message(this.validation.$params[type])
+          : message
+      }
     }
   }
 }

--- a/mixins/validationHelpers.js
+++ b/mixins/validationHelpers.js
@@ -1,114 +1,34 @@
+/**
+ * This is a mixin for the form you want to validate.
+ *
+ * It does not include vuelidate, so include that too in your form component.
+ */
 export default {
-  props: {
-    /**
-     * The vuelidate validation object for this field.
-     * Available under "$v.your.validated.field"
-     * e.g. "$v.event.title"
-     */
-    validation: {
-      type: Object,
-      required: true
-    },
-    /**
-     * We want to control whether to enable the validation to not
-     * overwhelm the user as they write.
-     */
-    validationEnabled: {
-      type: Boolean,
-      default: false
-    },
-    /**
-     * vuelidate does not help us with the messages to show, this lets us
-     * specify the error message for each associated validation type, e.g:
-     *
-     *   {
-     *     required: 'Please add a foo'
-     *   }
-     *
-     * If you pass in a function it will pass you the vuelidate config for that
-     * validation: e.g.
-     *
-     *   {
-     *     maxLength: ({ max }) => `Please make it less than ${max}`
-     *   }
-     */
-    validationMessages: {
-      type: Object,
-      required: true
+  computed: {
+    validationEnabled() {
+      return this.$v.$dirty
     }
   },
-  computed: {
-    /**
-     * The errors come with a nice element to show the error messages.
-     * It will use this as it's id
-     *
-     * @returns {string}
-     */
-    feedbackId() {
-      return this.$attrs.id + '-feedback'
-    },
-    /**
-     * All the available validation types on this field.
-     * e.g. ['required', 'maxLength']
-     *
-     * @returns {string[]}
-     */
-    validationTypes() {
-      return Object.keys(this.validation).filter(k => !/^$/.test(k))
-    },
-    /**
-     * All the validation types that have an error.
-     * e.g. ['required']
-     *
-     * @returns {string[]}
-     */
-    validationErrorTypes() {
-      return this.validationEnabled
-        ? this.validationTypes.filter(k => !this.validation[k])
-        : []
-    },
-    /**
-     * Is there at least one error?
-     *
-     * @returns {true|false}
-     */
-    hasValidationError() {
-      return this.validationEnabled && this.validation.$dirty
-        ? this.validation.$error
-        : false
-    },
-    /**
-     * Useful for putting in the bootstrap :state prop
-     *
-     *   true  -> valid
-     *   false -> invalid
-     *   null  -> not validated yet, neutral
-     *
-     * @returns {true|false|null}
-     */
-    validationState() {
-      return this.validationEnabled && this.validation.$dirty
-        ? !this.validation.$error
-        : null
-    },
-    /**
-     * Returns the first error message if there are validation errors.
-     * It's a bit overwhelming to show them all errors at once.
-     * The order of how to show them if there are multiple errors
-     * is detirmined by the order returned by "validationTypes".
-     *
-     * The messages come from the "validationMessages" prop.
-     *
-     * @returns {string|undefined}
-     */
-    firstValidationError() {
-      if (this.validationErrorTypes.length > 0) {
-        const type = this.validationErrorTypes[0]
-        const message = this.validationMessages[type]
-        return typeof message === 'function'
-          ? message(this.validation.$params[type])
-          : message
+  methods: {
+    validationFocusFirstError() {
+      const el = this.$refs.form
+      if (!el) return // no ref :/
+      // We want to scroll to the form group, so the label is visible
+      const scrollToEl = el.querySelector('.is-invalid')
+      // ... but focus the first input field
+      const focusEl = el.querySelector('input.is-invalid, textarea.is-invalid')
+      if (scrollToEl) scrollToEl.scrollIntoView()
+      if (focusEl) {
+        if (!scrollToEl) {
+          // we can make do with scrolling to the input
+          focusEl.scrollIntoView()
+        }
+        focusEl.focus()
+      } else if (!scrollToEl) {
+        // nothing else found, just scroll to the form itself...
+        el.scrollIntoView()
       }
+      return scrollToEl || focusEl
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7283,6 +7283,11 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13389,6 +13389,11 @@
         "vue": "^2.5.17"
       }
     },
+    "vuelidate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.4.tgz",
+      "integrity": "sha512-QHZWYOL325Zo+2K7VBNEJTZ496Kd8Z31p85aQJFldKudUUGBmgw4zu4ghl4CyqPwjRCmqZ9lDdx4FSdMnu4fGg=="
+    },
     "vuex": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vue2-filters": "^0.7.0",
     "vue2-google-maps": "^0.10.7",
     "vuejs-thermometer": "0.0.4",
+    "vuelidate": "^0.7.4",
     "vuex-persistedstate": "^2.5.4",
     "wicket": "^1.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.15",
     "lodash.assign": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "nchan": "^1.0.10",
     "nuxt": "^2.8.1",

--- a/store/communityevents.js
+++ b/store/communityevents.js
@@ -162,6 +162,7 @@ export const actions = {
   async add({ commit, dispatch }, event) {
     const { id } = await this.$api.communityevent.create(event)
     await dispatch('fetch', { id })
+    return id
   },
   async addGroup({ commit, dispatch }, { id, groupid }) {
     await this.$api.communityevent.addGroup(id, groupid)


### PR DESCRIPTION
So, the idea for this is to use vuelidate, I'm already familiar with it, and it's the first suggestion given on the [boostrap-vue validation page](https://bootstrap-vue.js.org/docs/reference/validation/#form-validation) too.

One of the things that it doesn't do for you is the error message handling, leaving that to you - which is a reasonable idea as there are many ways to show/display/fetch the actual error messages. The downside is it can get quite verbose and repetitive. So, I thought to create new form components that wrap the bootstrap ones to take the tedium out of it.

It basically passes everything through to the underlying component, apart from the props `validation` (the vuelidate object representing a specific field) and `validation-messages` (a map of validation type -> message) which it uses itself.

I used the same pattern as shown in the bootstrap-vue docs, so it looks a bit like this:

![validation](https://user-images.githubusercontent.com/31616/69989087-2f5f7a80-1543-11ea-9a07-39d2e30985a8.png)

How do you feel about this general approach (wrapping the bootstrap form components)?

The other question that quickly arises is what the validation rules actually be? I wonder if there is a reference somewhere I can follow? (maybe the backend has some hints? or the old frontend?).