### PR TITLE
Set the initial height of the sidebar items

### DIFF
--- a/components/SidebarRight.vue
+++ b/components/SidebarRight.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="d-flex flex-column sidebar__wrapper">
-    <VolunteerOpportunitySidebar v-if="showVolunteerOpportunities" class="justify-content-start flex-grow-1" style="overflow-y: auto" />
-    <JobsSidebar v-if="showJobOpportunities" class="justify-content-end flex-grow-1" style="overflow-y: auto" />
-    <!--    TODO DESIGN make these equal height-->
+    <VolunteerOpportunitySidebar v-if="showVolunteerOpportunities" class="sidebar__item" />
+    <JobsSidebar v-if="showJobOpportunities" class="sidebar__item" />
   </div>
 </template>
 
@@ -32,5 +31,10 @@ export default {
 <style scoped>
 .sidebar__wrapper {
   height: calc(100vh - 100px);
+}
+
+.sidebar__item {
+  flex: 0 1 50%;
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
Resolve the TODO to make the sidebar items equal height.  When there is only one present then it should still only take up 50% of the space.

To do this I'm using flex-basis to set the initial size of each sidebar item to be 50% of the sidebar height.  I've also set flex-grow to be 0 so if there is only one item then it doesn't fill the whole 100% of space.  flex-shrink is left at the default.