### PR TITLE
Move the centre aligning out of postcode and into the parent

### DIFF
--- a/components/AddressModal.vue
+++ b/components/AddressModal.vue
@@ -61,7 +61,6 @@
             <p>Choose a postcode:</p>
             <b-row>
               <b-col>
-                <!--              TODO DESIGN Postcode is center-aligned, which looks wrong.-->
                 <Postcode @selected="postcodeSelect" @cleared="postcodeCleared" />
               </b-col>
             </b-row>

--- a/components/Postcode.vue
+++ b/components/Postcode.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex justify-content-center">
+  <div class="d-flex">
     <autocomplete
       ref="autocomplete"
       :url="source"

--- a/pages/find/index.vue
+++ b/pages/find/index.vue
@@ -11,7 +11,7 @@
         </p>
         <b-row>
           <b-col class="text-center">
-            <postcode @selected="postcodeSelect" @cleared="postcodeClear" />
+            <postcode class="justify-content-center" @selected="postcodeSelect" @cleared="postcodeClear" />
           </b-col>
         </b-row>
         <transition name="fade">

--- a/pages/give/index.vue
+++ b/pages/give/index.vue
@@ -12,7 +12,7 @@
         </p>
         <b-row>
           <b-col class="text-center">
-            <postcode @selected="postcodeSelect" @cleared="postcodeClear" />
+            <postcode class="justify-content-center" @selected="postcodeSelect" @cleared="postcodeClear" />
           </b-col>
         </b-row>
         <transition name="fade">


### PR DESCRIPTION
Fix the TODO for postcode alignment.

The alignment of the postcode element should be dealt with by the parent rather than the postcode component itself.