### PR TITLE
Add visibility watcher

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,6 +79,7 @@ module.exports = {
     { src: '~/plugins/dayjs'},
 
     // Some plugins are client-side features
+    { src: '~plugins/visibility.js', ssr: false },
     { src: '~plugins/error-toasts.js', ssr: false },
     { src: '~plugins/vuex-persistedstate', ssr: false },
     { src: '~plugins/vue-drag-drop.js', ssr: false },

--- a/plugins/visibility.js
+++ b/plugins/visibility.js
@@ -1,0 +1,13 @@
+import visibility from '@/utils/visibility'
+
+export default ({ store }) => {
+  store.watch(
+    () => visibility.visible,
+    visible => {
+      if (visible) {
+        store.dispatch('notifications/count')
+        store.dispatch('notifications/list')
+      }
+    }
+  )
+}

--- a/utils/visibility.js
+++ b/utils/visibility.js
@@ -1,0 +1,84 @@
+/**
+ * Determine whether the page/tab/app is visible for the user (or hidden away in a tab, in background, etc).
+ *
+ * It exposes a reactive object with one boolean property "visible", you can use this in components, computed methods,
+ * store watchers, or whatever really.
+ *
+ * In Vue v3 there will be a watch API [1] that you can use outside of components, or stores, but for now we can (ab)use
+ * the store watch API, e.g.
+ *
+ *    store.watch(
+ *      () => visibility.visible,
+ *      visible => {
+ *        if (visible) {
+ *          console.log('I just became visible!')
+ *        }
+ *      }
+ *    )
+ *
+ * Implementation is a mixture of:
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+ * - https://github.com/quasarframework/quasar/blob/dev/ui/src/plugins/AppVisibility.js
+ * - https://github.com/yunity/karrot-frontend/blob/master/src/utils/datastore/presenceReporter.js
+ *
+ * [1] https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#watchers
+ */
+import Vue from 'vue'
+
+const state = Vue.observable({ visible: true })
+
+setupVisiblityListener(visible => {
+  state.visible = visible
+})
+
+setupTimer(visible => {
+  state.visible = visible
+})
+
+export default state
+
+function setupVisiblityListener(onUpdate) {
+  let prop, evt
+
+  if (typeof document.hidden !== 'undefined') {
+    // Opera 12.10 and Firefox 18 and later support
+    prop = 'hidden'
+    evt = 'visibilitychange'
+  } else if (typeof document.msHidden !== 'undefined') {
+    prop = 'msHidden'
+    evt = 'msvisibilitychange'
+  } else if (typeof document.webkitHidden !== 'undefined') {
+    prop = 'webkitHidden'
+    evt = 'webkitvisibilitychange'
+  }
+
+  const update = () => {
+    onUpdate(!document[prop])
+  }
+
+  update()
+
+  if (evt && typeof document[prop] !== 'undefined') {
+    document.addEventListener(evt, update, false)
+  }
+}
+
+function setupTimer(onUpdate) {
+  let timer
+  const resetTimer = e => {
+    clearTimeout(timer)
+    onUpdate(true)
+    timer = setTimeout(() => onUpdate(false), 30 * 1000) // 30 seconds
+  }
+  ;[
+    'load',
+    'mousemove',
+    'keydown',
+    'DOMMouseScroll',
+    'mousewheel',
+    'mousedown',
+    'touchstart',
+    'touchmove',
+    'click'
+  ].forEach(event => document.addEventListener(event, resetTimer))
+}


### PR DESCRIPTION
A first pass at a visibility watcher, re: https://app.slack.com/team/U6MA8D84T

A few random thoughts:
- maybe should include "time since last visible", as you might not want to _always_ refresh things, if it is heavy to do so
- perhaps we don't need the event timer based detection (that detects idling on the page, like maybe you left the window open for some time, then came back) - I'm not sure why we added this in karrot, maybe to support browsers that don't support visibility API (though looks not too bad, https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API#Browser_compatibility), or maybe some edge cases :/
- I made it trigger `notifications/count` and `notifications/list`, but not sure if that is correct