### PR TITLE
Fix redirect loop in createGroupRoute mixin

### DIFF
--- a/mixins/createGroupRoute.js
+++ b/mixins/createGroupRoute.js
@@ -60,6 +60,10 @@ export default function createGroupRoute(key, options = {}) {
       rememberedValue: {
         immediate: true,
         handler(val) {
+          // If we have already triggered a route we don't want to do
+          // any more logic about the remembered value on this page
+          // it will trigger a redirect loop otherwise
+          if (this.$router.history.pending) return
           if (val === undefined && this.groupid !== DEFAULT_VALUE) {
             // Nothing set so far... make it what our current page is
             this.updateMemory(this.groupid)


### PR DESCRIPTION
When there was an invalid value selected, the GroupSelect component would set the groupid back to null, and we would forget the value and reroute back to the main page...

... BUT the remembered value watcher would see the value go back to undefined, and, using the current route param (the invalid id) set it all up again, hence an infinite loop.

The fix is to understand that once we've triggered a route change we should do no more logic on this component. Once the route has changed, it'll be all fresh again :)