### PR TITLE
Set axios base url

### DIFF
--- a/api/BaseAPI.js
+++ b/api/BaseAPI.js
@@ -21,13 +21,7 @@ export default class BaseAPI {
     const { status, data } = await this.$axios.request({
       ...config,
       method,
-      url: path,
-      // TODO NS BUG I've hacked the next line to make SSR work in dev environments.  Please decide what the correct
-      // fix is.
-      baseURL:
-        process.env.NODE_ENV === 'development'
-          ? 'http://localhost:3000/api'
-          : process.env.API
+      url: process.env.API + path
     })
     if (
       status !== 200 ||

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,9 +9,9 @@ const API = '/api'
 // This is where the user site is.
 const USER_SITE = 'https://www.ilovefreegle.org'
 
-// PROXY_API is where we send it to.  This avoids CORS issues (and removes preflight OPTIONS calls for GETs, which
+// IZNIK_API is where we send it to.  This avoids CORS issues (and removes preflight OPTIONS calls for GETs, which
 // hurt client performance).
-const PROXY_API = process.env.IZNIK_API || 'https://iznik.ilovefreegle.org'
+const IZNIK_API = process.env.IZNIK_API || 'https://iznik.ilovefreegle.org'
 
 // Long polls interact badly with per-host connection limits so send to here instead.
 const CHAT_HOST = 'https://users.ilovefreegle.org:555'
@@ -76,6 +76,7 @@ module.exports = {
     { src: '~/plugins/twemoji' },
     { src: '~/plugins/vue2-filters' },
     { src: '~/plugins/axios-token' },
+    { src: '~/plugins/axios-baseurl' },
     { src: '~/plugins/dayjs'},
 
     // Some plugins are client-side features
@@ -187,7 +188,7 @@ module.exports = {
     proxy: true
   },
   proxy: {
-    '/api/': PROXY_API,
+    '/api/': IZNIK_API,
     '/adview.php': USER_SITE + '/adview.php'
   },
 
@@ -258,6 +259,7 @@ module.exports = {
 
   env: {
     API: API,
+    IZNIK_API: IZNIK_API,
     CHAT_HOST: CHAT_HOST,
     FACEBOOK_APPID: FACEBOOK_APPID,
     GOOGLE_MAPS_KEY: 'AIzaSyCdTSJKGWJUOx2pq1Y0f5in5g4kKAO5dgg',

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -234,7 +234,6 @@ export default {
     })
 
     const board = store.getters['team/get']
-    console.log('BOard', board)
 
     return {
       board: board.members,

--- a/plugins/axios-baseurl.js
+++ b/plugins/axios-baseurl.js
@@ -1,0 +1,21 @@
+/**
+ * Set the axios baseURL depending on whether we are server or client.
+ *
+ *   server:
+ *
+ *     - set baseURL to IZNIK_API
+ *     - makes requests to the directly to the API
+ *     - we don't need to worry about the CORS stuff
+ *
+ *   client:
+ *
+ *     - no baseURL set
+ *     - makes API requests to current hostname in browser
+ *     - the backend that served us is responsible for proxying to the right place
+ *
+ */
+export default function({ $axios }) {
+  if (process.server) {
+    $axios.defaults.baseURL = process.env.IZNIK_API
+  }
+}

--- a/store/team.js
+++ b/store/team.js
@@ -23,7 +23,6 @@ export const getters = {
 export const actions = {
   async fetch({ commit }, params) {
     const team = await this.$api.team.fetch(params)
-    console.log('Got', team)
     commit('set', team)
   },
 


### PR DESCRIPTION
I'm not 100% sure how it works when running on the actual server, but I _think_ this should do the trick.

Basically, we can set the axios baseURL in a plugin to be correct depending on whether we're on the server (request `IZNIK_API`) or the client (request from whatever domain we were served from).

I did sort of want to remove/combine this with the `process.env.API` configuration too, but they are not really related... so I left that one as-is.

There were two other approaches I would have liked to use, but they are not possible:
1. set the nuxt env differently depending on whether we are server or client (https://github.com/nuxt/nuxt.js/issues/6629)
2. use the nuxt/axios options which exposes `baseURL` (server) and `browserBaseURL` (client) options but doesn't place nicely with the `proxy` option, and seemed confusing (see https://axios.nuxtjs.org/options)

I verified I can load http://localhost:3000/volunteering/12869 via SSR and it makes the axios request correctly, and can also browse around the site with non-SSR requests working too.