### PR TITLE
Return data from auth save email action

### DIFF
--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -676,11 +676,11 @@ export default {
       this.savingEmail = true
 
       if (this.me.email) {
-        const ret = await this.$store.dispatch('auth/saveEmail', {
+        const data = await this.$store.dispatch('auth/saveEmail', {
           email: this.me.email
         })
 
-        if (ret && ret.data && ret.data.ret === 10) {
+        if (data && data.ret === 10) {
           this.$refs.emailconfirm.show()
         }
       }

--- a/store/auth.js
+++ b/store/auth.js
@@ -235,12 +235,11 @@ export const actions = {
   },
 
   async saveEmail({ commit, dispatch, state }, params) {
-    await this.$api.session.save(params)
+    const data = await this.$api.session.save(params)
     await dispatch('fetchUser', {
       components: ['me', 'groups', 'aboutme']
     })
-    // TODO NS BUG: no longer returning res, does it break anything?  Yes, I think it does - see use in settings/index.vue
-    // where we consider showing a modal.
+    return data
   },
 
   async saveAndGet({ commit, dispatch, state }, params) {

--- a/store/auth.js
+++ b/store/auth.js
@@ -248,7 +248,6 @@ export const actions = {
       components: NONMIN,
       force: true
     })
-    // TODO NS: should we rely on returning this?  EH We definitely do, and the clue is in the name.  I'd just remove this.
     return state.user
   },
 


### PR DESCRIPTION
As per [discussion in slack](https://freegle.slack.com/archives/C6LCTJ280/p1576002944121700?thread_ts=1575996858.120400&cid=C6LCTJ280) - just doing the simplest fix, to return data from the action.

It's slightly different to how was before as it's not the axios result object, but the data object inside it.

Confession: I did not actually try it.

(I also would have liked to remove the magic number 10 (meaning the email address needs verification), but went with the smallest possible fix)