### PR TITLE
Remove deprecated option for sitemap-module

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -384,7 +384,6 @@ module.exports = {
     },
     exclude: sitemap.excludeRoutes,
     path: '/sitemap.xml',
-    gzip: true,
-    generate: false
+    gzip: true
   }
 }


### PR DESCRIPTION
Since v1.x
see https://github.com/nuxt-community/sitemap-module/blob/dev/lib/options.js#L35-L38