### PR TITLE
Make the /spread page white background by default

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -104,9 +104,6 @@ div[variant="success"] .card-header {
 }
 
 body {
-  //TODO DESIGN I'm really attached to this wallpaper.  White backgrounds are cold, and we want a warm feel.  But
-  //on pages which are text-heavy (e.g. /spread) then it's hard to read the text.
-  //On the old site I removed the wallpaper on such pages.  Should we do that or something better?
   background-image: url('~static/wallpaper.png');
 }
 

--- a/pages/spread.vue
+++ b/pages/spread.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-row class="m-0">
+  <b-row class="m-0 bg-white">
     <b-col cols="0" md="3" />
     <b-col cols="12" md="6" class="mt-2">
       <h2>


### PR DESCRIPTION
Not sure what else to suggest for this TODO item, imo anything else is going to need a large site wide redesign in oder to incorporate the wallpaper and some sort of white wrapper around pages that are text heavy. I dont personally see anything wrong with the approach we're already using on other pages (like /help) - by default pages have the wallpaper, override where required.

As above, anything else feels like a site wide redesign with a white background container (set width) that sits on top of the wallpaper.

I do think this page needs some attention though, perhaps some sort of accordion?