### PR TITLE
Upgrade LazyYoutubeVideo and use esm version

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -309,7 +309,7 @@ module.exports = {
   build: {
     // analyze: true,
 
-    transpile: [/^vue2-google-maps($|\/)/],
+    transpile: [/^vue2-google-maps($|\/)/, 'vue-lazy-youtube-video'],
 
     extend(config, ctx) {
       if (process.env.NODE_ENV !== 'production') {
@@ -367,7 +367,13 @@ module.exports = {
         const targets = isServer
           ? { node: '10' }
           : {
-              browsers: ['> 1%', 'last 2 versions', 'ie >= 8', 'safari >= 9']
+              browsers: [
+                '> 1%',
+                'last 2 versions',
+                'ie >= 8',
+                'safari >= 9',
+                'ios_saf >= 9'
+              ]
             }
         return [
           [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13072,9 +13072,9 @@
       "integrity": "sha512-thZrceEBt9HqEX94/xnws5N/d165BIXbLY1VPeT2UyDP8jbGNC54+wzzJuLFF1teZLtTRfNOz8wf8bmuoJ/kRw=="
     },
     "vue-lazy-youtube-video": {
-      "version": "1.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/vue-lazy-youtube-video/-/vue-lazy-youtube-video-1.3.0-beta.1.tgz",
-      "integrity": "sha512-o+LWilSEO5k1PAi26Wjl8Mtu6rUgEvKCcyxFOlA/CsQFF4Og4oKt+Nay7RNo54oGWdfJp8tnlxqjrR5Am+svTw=="
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/vue-lazy-youtube-video/-/vue-lazy-youtube-video-2.0.0-beta.0.tgz",
+      "integrity": "sha512-XdGMQR+cEmDOYTUhz45SlRBrBEhpETkJKhOvNStRMqwhqG3UycEc7L4HMnY4UWri1PR0L8ddFt6dXhvL3d1JNQ=="
     },
     "vue-loader": {
       "version": "15.7.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vue-infinite-loading": "github:PeachScript/vue-infinite-loading#master",
     "vue-js-toggle-button": "^1.3.2",
     "vue-json-pretty": "^1.6.2",
-    "vue-lazy-youtube-video": "^1.3.0-beta.1",
+    "vue-lazy-youtube-video": "^2.0.0-beta.0",
     "vue-read-more": "^1.1.1",
     "vue-resize-text": "^0.1.0",
     "vue-social-sharing": "^2.4.6",

--- a/pages/councils/othercouncils.vue
+++ b/pages/councils/othercouncils.vue
@@ -112,7 +112,7 @@
             Cumbria County Council have also produced this child-friendly video as part of their ‘Rubbish Rebels’ series.
           </p>
           <client-only>
-            <LazyYoutubeVideo url="https://www.youtube.com/watch?v=EvQKfTg82fI" />
+            <LazyYoutubeVideo src="https://www.youtube.com/embed/EvQKfTg82fI" />
           </client-only>
 
           <h3>Radio</h3>

--- a/pages/councils/photosvideos.vue
+++ b/pages/councils/photosvideos.vue
@@ -32,7 +32,7 @@
             social media.
           </p>
           <client-only>
-            <LazyYoutubeVideo url="https://www.youtube.com/watch?v=Gw_wpkbNQY8" />
+            <LazyYoutubeVideo src="https://www.youtube.com/embed/Gw_wpkbNQY8" />
           </client-only>
           <p>
             We can provide the video source files <a href="mailto:councils@ilovefreegle.org">on request</a>.

--- a/pages/councils/why.vue
+++ b/pages/councils/why.vue
@@ -9,7 +9,7 @@
         </b-card-header>
         <b-card-text class="pl-2 pr-2">
           <client-only>
-            <LazyYoutubeVideo url="https://www.youtube.com/watch?v=hXNWj2sZ7ZM" />
+            <LazyYoutubeVideo src="https://www.youtube.com/embed/hXNWj2sZ7ZM" />
           </client-only>
           <p>
             There are many charities and other organisations that councils promote and work with to encourage reuse

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -39,7 +39,7 @@
         <b-row class="mt-4">
           <b-col>
             <client-only>
-              <LazyYoutubeVideo url="https://www.youtube.com/watch?v=Gw_wpkbNQY8" />
+              <LazyYoutubeVideo src="https://www.youtube.com/embed/Gw_wpkbNQY8" />
             </client-only>
           </b-col>
         </b-row>

--- a/plugins/vue-lazy-youtube-video.js
+++ b/plugins/vue-lazy-youtube-video.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { Plugin } from 'vue-lazy-youtube-video/dist/vue-lazy-youtube-video.ssr.common'
-// have to import ejected style directly, see this issue https://github.com/vuejs/rollup-plugin-vue/issues/266
+import { Plugin } from 'vue-lazy-youtube-video/dist/vue-lazy-youtube-video.esm'
+// // have to import ejected style directly, see this issue https://github.com/vuejs/rollup-plugin-vue/issues/266
 import 'vue-lazy-youtube-video/dist/style.css'
 
 Vue.use(Plugin)


### PR DESCRIPTION
Uses latest version of lazy youtube lib, updating usage to fit new way.

Also uses esm version + transpile setting to ensure es6 doesn't sneak into the output builds.

I added `ios_saf >= 9` in our browserslist config in a vain attempt to support it, it's not enough (get  `Typeerror: Type error` in the console) but maybe helps a bit...