### PR TITLE
Add moderator leaf image to profile picture where required.

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -118,26 +118,6 @@ body {
   background-image: url('~static/wallpaper.png');
 }
 
-.showmod {
-  border-radius: 50%;
-  position: absolute;
-  background-color: $color-white;
-  width: 24px;
-  height: 24px;
-  padding-left: 3px;
-  padding-top: 4px;
-  padding-right: 2px;
-  border: 1px solid $color-green--darker;
-
-  top: 20px;
-  left: 33px;
-
-  @media (min-width: $bootstrap-sm) {
-    top: 29px;
-    left: 44px;
-  }
-}
-
 // We have to go to some effort to style the resize grip.  We can't have it in a scoped style otherwise it won't
 // apply to the grip, and the image is small enough that it gets inlined into base64, so we can't use an
 // image file - instead we encode it here.

--- a/components/NewsCommunityEvent.vue
+++ b/components/NewsCommunityEvent.vue
@@ -2,8 +2,14 @@
   <div>
     <b-row>
       <b-col>
-        <profile-image v-if="users[userid].profile.turl" :image="users[userid].profile.turl" class="mr-1 mb-1 mt-1 inline" is-thumbnail size="lg" />
-        <v-icon v-if="users[userid].settings.showmod" name="leaf" class="showmod text-success" />
+        <profile-image
+          v-if="users[userid].profile.turl"
+          :image="users[userid].profile.turl"
+          class="mr-1 mb-1 mt-1 inline"
+          is-thumbnail
+          :is-moderator="users[userid].settings.showmod"
+          size="lg"
+        />
         <span class="text-success font-weight-bold">{{ users[userid].displayname }}</span>
         created an event<span class="d-none d-md-inline-block">:</span><br class="d-block d-md-none"> <b>{{ newsfeed.communityevent.title }}</b>
         <br>

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -6,8 +6,12 @@
           <tbody>
             <tr>
               <td style="vertical-align: top" class="clickme" title="Click to see their profile" @click="showInfo">
-                <profile-image :image="users[userid].profile.turl" class="ml-1 mr-2 mt-2 mb-1 inline float-left" :size="(reply.replyto !== threadhead.id) ? 'sm' : 'md'" />
-                <v-icon v-if="users[userid].settings.showmod && reply.replyto === threadhead.id" name="leaf" class="showmodsm text-success" />
+                <profile-image
+                  :image="users[userid].profile.turl"
+                  class="ml-1 mr-2 mt-2 mb-1 inline float-left"
+                  :is-moderator="users[userid].settings.showmod && reply.replyto === threadhead.id"
+                  :size="(reply.replyto !== threadhead.id) ? 'sm' : 'md'"
+                />
               </td>
               <td class="align-top">
                 <span class="text-success font-weight-bold clickme" title="Click to see their profile" @click="showInfo">{{ users[userid].displayname }}</span>
@@ -463,23 +467,5 @@ export default {
 .replytext {
   font-size: 14px;
   line-height: 1.2;
-}
-
-.showmodsm {
-  border-radius: 50%;
-  position: absolute;
-  background-color: $color-white;
-  width: 16px;
-  height: auto;
-  top: 19px;
-  left: 16px;
-  padding: 2px;
-
-  @include media-breakpoint-up(md) {
-    width: 20px;
-    top: 28px;
-    left: 28px;
-    padding: 3px;
-  }
 }
 </style>

--- a/components/NewsUserIntro.vue
+++ b/components/NewsUserIntro.vue
@@ -3,8 +3,14 @@
     <div class="media clickme">
       <div class="media-left">
         <div class="media-object">
-          <profile-image v-if="users[userid].profile.turl" :image="users[userid].profile.turl" class="ml-1 mb-1 inline" is-thumbnail size="lg" />
-          <v-icon v-if="users[userid].settings.showmod" name="leaf" class="showmod text-success" />
+          <profile-image
+            v-if="users[userid].profile.turl"
+            :image="users[userid].profile.turl"
+            class="ml-1 mb-1 inline"
+            is-thumbnail
+            :is-moderator="users[userid].settings.showmod"
+            size="lg"
+          />
         </div>
       </div>
       <div class="media-body ml-2">

--- a/components/NewsVolunteerOpportunity.vue
+++ b/components/NewsVolunteerOpportunity.vue
@@ -2,8 +2,14 @@
   <div>
     <b-row>
       <b-col>
-        <profile-image v-if="users[userid].profile.turl" :image="users[userid].profile.turl" class="ml-1 mr-2 mb-1 inline" is-thumbnail size="lg" />
-        <v-icon v-if="users[userid].settings.showmod" name="leaf" class="showmod text-success" />
+        <profile-image
+          v-if="users[userid].profile.turl"
+          :image="users[userid].profile.turl"
+          class="ml-1 mr-2 mb-1 inline"
+          is-thumbnail
+          :is-moderator="users[userid].settings.showmod"
+          size="lg"
+        />
         <span class="text-success font-weight-bold">{{ users[userid].displayname }}</span>
         posted a volunteering opportunity<span class="d-none d-md-inline-block">:</span><br class="d-block d-md-none"> <b>{{ newsfeed.volunteering.title }}</b>
         <br>

--- a/components/ProfileImage.vue
+++ b/components/ProfileImage.vue
@@ -1,14 +1,17 @@
 <template>
-  <b-img-lazy
-    rounded="circle"
-    :thumbnail="isThumbnail"
-    class="p-0"
-    :class="'profile--' + size"
-    :alt="altText"
-    title="Profile"
-    :src="image"
-    @error.native="brokenProfileImage"
-  />
+  <div class="profile-image__container">
+    <b-img-lazy
+      rounded="circle"
+      :thumbnail="isThumbnail"
+      class="p-0"
+      :class="'profile--' + size"
+      :alt="altText"
+      title="Profile"
+      :src="image"
+      @error.native="brokenProfileImage"
+    />
+    <v-icon v-if="isModerator" name="leaf" class="profile-image__moderator mb-0" :class="'profile-image__moderator--' + size" />
+  </div>
 </template>
 
 <script>
@@ -32,6 +35,10 @@ export default {
       type: Boolean,
       required: false
     },
+    isModerator: {
+      type: Boolean,
+      required: false
+    },
     size: {
       type: String,
       required: false,
@@ -47,6 +54,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import 'color-vars';
 @import 'bootstrap/scss/_functions';
 @import 'bootstrap/scss/_variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
@@ -88,6 +96,69 @@ export default {
   @include media-breakpoint-up(md) {
     width: 100px;
     height: 100px;
+  }
+}
+
+.profile-image__container {
+  position: relative;
+  padding-right: 5px;
+  padding-bottom: 3px;
+}
+
+.profile-image__moderator {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background-color: $color-white;
+  border-radius: 50%;
+  color: $colour-success;
+}
+
+.profile-image__moderator--sm {
+  padding: 2px;
+  width: 12px;
+  height: 12px;
+
+  @include media-breakpoint-up(md) {
+    padding: 3px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.profile-image__moderator--md {
+  padding: 2px;
+  width: 16px;
+  height: 16px;
+
+  @include media-breakpoint-up(md) {
+    padding: 3px;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.profile-image__moderator--lg {
+  padding: 2px;
+  width: 18px;
+  height: 18px;
+
+  @include media-breakpoint-up(md) {
+    padding: 3px;
+    width: 24px;
+    height: 24px;
+  }
+}
+
+.profile-image__moderator--xl {
+  padding: 2px;
+  width: 24px;
+  height: 24px;
+
+  @include media-breakpoint-up(md) {
+    padding: 3px;
+    width: 36px;
+    height: 36px;
   }
 }
 </style>


### PR DESCRIPTION
Move the moderator "leaf" functionality into the profile-image component.  That way it can be more easily positioned over the profile image.

@edwh - You might want to check that you are happy with the size and the position.  These are now linked up to the size of the profile image so can easily be tweaked.