### PR TITLE
#142 improve group header layout to avoid any overlap, obtuse or odd …

### DIFF
--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -13,21 +13,19 @@
         <p v-if="group.membercount" class="text-muted small">
           Founded {{ group.founded | dateonly }}. {{ group.membercount.toLocaleString() }} current freeglers.
           <br>
-          <span>
-            See
-            <nuxt-link :to="{ path: '/communityevents/' + group.id }">
-              community events
-            </nuxt-link>,
-            <nuxt-link :to="{ path: '/volunteerings/' + group.id }">
-              volunteer opportunities
-            </nuxt-link>,
-            <nuxt-link :to="{ path: '/stories/' + group.id }">
-              stories
-            </nuxt-link>, or
-            <nuxt-link :to="{ path: '/stats/' + group.nameshort }">
-              stats
-            </nuxt-link>
-          </span>
+          See
+          <nuxt-link :to="{ path: '/communityevents/' + group.id }">
+            community events
+          </nuxt-link>,
+          <nuxt-link :to="{ path: '/volunteerings/' + group.id }">
+            volunteer opportunities
+          </nuxt-link>,
+          <nuxt-link :to="{ path: '/stories/' + group.id }">
+            stories
+          </nuxt-link>, or
+          <nuxt-link :to="{ path: '/stats/' + group.nameshort }">
+            stats
+          </nuxt-link>
         </p>
       </b-col>
       <b-col cols="12" md="4" lg="12" class="group-header-buttons">

--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -1,10 +1,10 @@
 <template>
   <b-card bg-light>
     <b-row v-if="group.profile" class="mt-1">
-      <b-col cols="4" sm="2" lg="3" xl="2">
+      <b-col cols="4" md="2" lg="3" xl="2">
         <b-img-lazy rounded thumbnail alt="Community profile picture" :src="group.profile" class="js-pageimage" />
       </b-col>
-      <b-col cols="8" sm="5" lg="9" xl="5">
+      <b-col cols="8" md="6" lg="9" class="group-header-description">
         <b-card-title>
           {{ group.namedisplay }}
           <v-icon v-if="amAMember === 'Owner' || amAMember === 'Moderator'" name="crown" class="text-success" :title="'You have role ' + amAMember" />
@@ -13,22 +13,24 @@
         <p v-if="group.membercount" class="text-muted small">
           Founded {{ group.founded | dateonly }}. {{ group.membercount.toLocaleString() }} current freeglers.
           <br>
-          See
-          <nuxt-link :to="{ path: '/communityevents/' + group.id }">
-            community events
-          </nuxt-link>,
-          <nuxt-link :to="{ path: '/volunteerings/' + group.id }">
-            volunteer opportunities
-          </nuxt-link>,
-          <nuxt-link :to="{ path: '/stories/' + group.id }">
-            stories
-          </nuxt-link>, or
-          <nuxt-link :to="{ path: '/stats/' + group.nameshort }">
-            stats
-          </nuxt-link>
+          <span>
+            See
+            <nuxt-link :to="{ path: '/communityevents/' + group.id }">
+              community events
+            </nuxt-link>,
+            <nuxt-link :to="{ path: '/volunteerings/' + group.id }">
+              volunteer opportunities
+            </nuxt-link>,
+            <nuxt-link :to="{ path: '/stories/' + group.id }">
+              stories
+            </nuxt-link>, or
+            <nuxt-link :to="{ path: '/stats/' + group.nameshort }">
+              stats
+            </nuxt-link>
+          </span>
         </p>
       </b-col>
-      <b-col cols="12" sm="5" lg="12" xl="5" class="group-header-buttons">
+      <b-col cols="12" md="4" lg="12" class="group-header-buttons">
         <span>
           <b-link :href="'mailto:' + modsemail">
             <b-button class="ml-1 mb-1" variant="white">
@@ -60,8 +62,31 @@
 </template>
 
 <style scoped lang="scss">
+@import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/_breakpoints';
+
 .group-header-buttons {
+  margin-bottom: 20px;
   text-align: right;
+
+  @include media-breakpoint-up(xl) {
+    flex: 0 0 36%;
+    max-width: 36%;
+    padding-left: 0;
+  }
+}
+
+.group-header-description {
+  @include media-breakpoint-up(xl) {
+    padding-left: 0;
+    max-width: 47%;
+    flex: 0 0 47%;
+  }
+}
+
+.img-thumbnail {
   margin-bottom: 20px;
 }
 </style>

--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -1,27 +1,10 @@
 <template>
   <b-card bg-light>
     <b-row v-if="group.profile" class="mt-1">
-      <b-col lg="2" class="order-0">
+      <b-col cols="4" sm="2" lg="3" xl="2">
         <b-img-lazy rounded thumbnail alt="Community profile picture" :src="group.profile" class="js-pageimage" />
-        <span v-if="showJoin">
-          <b-button v-if="!amAMember" class="mt-1 float-right d-lg-none float-lg-none" variant="success" @click="join">
-            <v-icon v-if="joiningOrLeaving" name="sync" class="fa-spin" />
-            <v-icon v-else name="plus" />&nbsp;
-            Join
-          </b-button>
-          <b-button v-else-if="amAMember === 'Member'" class="mt-1 float-right d-lg-none float-lg-none" variant="white" @click="leave">
-            <v-icon v-if="joiningOrLeaving" name="sync" class="fa-spin" />
-            <v-icon v-else name="trash-alt" />&nbsp;
-            Leave
-          </b-button>
-        </span>
-        <b-link v-if="modsemail" :href="'mailto:' + modsemail">
-          <b-button class="mt-1 mr-1 d-block d-lg-none float-right" variant="white">
-            <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
-          </b-button>
-        </b-link>
       </b-col>
-      <b-col class="order-3 order-lg-1">
+      <b-col cols="8" sm="5" lg="9" xl="5">
         <b-card-title>
           {{ group.namedisplay }}
           <v-icon v-if="amAMember === 'Owner' || amAMember === 'Moderator'" name="crown" class="text-success" :title="'You have role ' + amAMember" />
@@ -45,8 +28,8 @@
           </nuxt-link>
         </p>
       </b-col>
-      <b-col lg="3" class="order-1 order-lg-2">
-        <span class="d-none d-lg-block float-right">
+      <b-col cols="12" sm="5" lg="12" xl="5" class="group-header-buttons">
+        <span>
           <b-link :href="'mailto:' + modsemail">
             <b-button class="ml-1 mb-1" variant="white">
               <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
@@ -75,6 +58,14 @@
     </b-row>
   </b-card>
 </template>
+
+<style scoped lang="scss">
+.group-header-buttons {
+  text-align: right;
+  margin-bottom: 20px;
+}
+</style>
+
 <script>
 export default {
   props: {


### PR DESCRIPTION
Id highly recommend pulling this down and taking a look before merge because

A) I cant find our discussion history (I seem to recall trying to avoid too much vertical whitespace or a logo too large)
B) This was really fiddly across different break points (IE between lg and xl, also 991/992 as this is when the overall layout changes from 12 columns to 6. 992 to 1199 would be my main concern as there just isnt enough horizontal space to get the 3 elements sitting side by side, hence the buttons sitting underneath, as they do on mobile).

Ive applied what I feel is best, as far as size of each element is concerned but as above, open to feedback at specific breakpoints whether we want a reposition of buttons etc.