### PR TITLE
Change the login elements to have flex-basis set as auto rather than …

### DIFF
--- a/components/LoginModal.vue
+++ b/components/LoginModal.vue
@@ -529,7 +529,7 @@ $color-google: #4285f4;
 $color-yahoo: #6b0094;
 
 .signin__section--social {
-  flex: 0 1 100%;
+  flex: 0 1 auto;
 
   @include media-breakpoint-up(lg) {
     flex: 0 1 37%;
@@ -537,7 +537,7 @@ $color-yahoo: #6b0094;
 }
 
 .signin__section--freegle {
-  flex: 0 1 100%;
+  flex: 0 1 auto;
 
   @include media-breakpoint-up(lg) {
     flex: 0 1 44%;


### PR DESCRIPTION
To steal a comment from a random site:

"Since you're setting the flex direction to column, the flex-basis value goes in the vertical direction, but the height of the container is determined by its children, so you have a circular reference and a percentage value is meaningless.

However, the items should, by default, not shrink below their minimum content size, but in Safari they're not honoring that. When you say 100%, since the height isn't fixed, that computes to 0, which is why you're seeing them all squished."

So basically 100% doesn't really make sense for the height but it's supported everywhere apart from Safari 9 and IE11.

I've only tested this very briefly at the moment.  I've tried it on Chrome and Firefox on desktop and using devtools on Safari 9.  Looks like the problem also happens on IE11 too which I've also only tested using devtools.