### PR TITLE
Remove all of the bootstrap rows/cols to sort out the mobile padding

### DIFF
--- a/components/NewsAlert.vue
+++ b/components/NewsAlert.vue
@@ -1,31 +1,26 @@
 <template>
   <div>
-    <b-row>
-      <b-col>
-        <profile-image :image="require(`@/static/icon.png`)" class="ml-1 mb-1 inline" is-thumbnail size="lg" />
-        <span class="text-success font-weight-bold pl-2">
-          Freegle
-        </span>
-        <br>
-        <span class="text-muted small pl-2">
-          {{ newsfeed.timestamp | timeago }}
-        </span>
-      </b-col>
-    </b-row>
+    <div>
+      <profile-image :image="require(`@/static/icon.png`)" class="ml-1 mb-1 inline" is-thumbnail size="lg" />
+      <span class="text-success font-weight-bold pl-2">
+        Freegle
+      </span>
+      <br>
+      <span class="text-muted small pl-2">
+        {{ newsfeed.timestamp | timeago }}
+      </span>
+    </div>
     <span v-if="newsfeed.message" class="font-weight-bold prewrap forcebreak">{{ emessage }}</span>
     <div>
-      <b-row v-if="newsfeed.image">
-        <b-col>
-          <b-img
-            v-b-modal="'photoModal-' + newsfeed.id"
-            thumbnail
-            rounded
-            lazy
-            :src="newsfeed.image.paththumb"
-            class="clickme"
-          />
-        </b-col>
-      </b-row>
+      <b-img
+        v-if="newsfeed.image"
+        v-b-modal="'photoModal-' + newsfeed.id"
+        thumbnail
+        rounded
+        lazy
+        :src="newsfeed.image.paththumb"
+        class="clickme"
+      />
     </div>
     <div class="mt-2">
       <NewsLoveComment :newsfeed="newsfeed" @focus-comment="$emit('focus-comment')" />


### PR DESCRIPTION
Fixing another one of the news components causing the padding issues on mobile.