### PR TITLE
Replace hardcoded bootstrap breakpoints with bootstrap functions

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -1,10 +1,5 @@
 @import 'color-vars';
 
-$bootstrap-xs: 576px;
-$bootstrap-sm: 768px;
-$bootstrap-md: 992px;
-$bootstrap-lg: 1200px;
-
 .bg-success {
   background-color: $colour-success-bg !important;
   color: $colour-success-fg !important;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -279,6 +279,9 @@
 
 <style scoped lang="scss">
 @import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/_breakpoints';
 
 html {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
@@ -334,8 +337,6 @@ nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
   }
 }
 
-$bootstrap-sm: 768px;
-
 #nav_collapse_mobile {
   margin-top: 5px;
 
@@ -351,7 +352,7 @@ $bootstrap-sm: 768px;
     flex-basis: 25%;
     margin: 20px 0;
 
-    @media (min-width: $bootstrap-sm) {
+    @include media-breakpoint-up(md) {
       flex-basis: unset;
     }
   }

--- a/pages/mydata.vue
+++ b/pages/mydata.vue
@@ -860,17 +860,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-$bootstrap-sm: 768px;
-
-.profile {
-  width: 35px !important;
-  height: 35px !important;
-
-  @media (min-width: $bootstrap-sm) {
-    width: 50px !important;
-    height: 50px !important;
-  }
-}
-</style>

--- a/pages/stats/_groupname.vue
+++ b/pages/stats/_groupname.vue
@@ -149,43 +149,7 @@
     </b-row>
   </div>
 </template>
-<style scoped lang="scss">
-@import 'color-vars';
 
-$bootstrap-sm: 768px;
-
-.chart-wrapper {
-  flex-direction: column;
-
-  @media (min-width: $bootstrap-sm) {
-    flex-direction: row;
-  }
-}
-
-.card {
-  &.chart {
-    height: 100%;
-  }
-}
-
-.titlelogo {
-  width: 140px;
-  height: 140px;
-  object-fit: cover;
-}
-
-.purple {
-  color: $color-purple !important;
-}
-
-.gold {
-  color: $color-gold !important;
-}
-
-.green {
-  color: green !important;
-}
-</style>
 <script>
 import dayjs from 'dayjs'
 import { GChart } from 'vue-google-charts'
@@ -480,3 +444,42 @@ export default {
   methods: {}
 }
 </script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/_breakpoints';
+
+.chart-wrapper {
+  flex-direction: column;
+
+  @include media-breakpoint-up(md) {
+    flex-direction: row;
+  }
+}
+
+.card {
+  &.chart {
+    height: 100%;
+  }
+}
+
+.titlelogo {
+  width: 140px;
+  height: 140px;
+  object-fit: cover;
+}
+
+.purple {
+  color: $color-purple !important;
+}
+
+.gold {
+  color: $color-gold !important;
+}
+
+.green {
+  color: green !important;
+}
+</style>


### PR DESCRIPTION
Remove the hardcoded breakpoints and use the bootstrap breakpoint functions instead.  They didn't actually correspond to the bootstrap ones anyway!

As far as I can tell you override the bootstrap versions by defining $grid-breakpoints.  When you hardcoded the values were you attempting to redefine the bootstrap ones or just have something to use in the code?  Just checking that I'm not missing anything.