### PR TITLE
Update the naming of some of the methods in the store

### DIFF
--- a/store/notifications.js
+++ b/store/notifications.js
@@ -74,7 +74,7 @@ export const getters = {
 }
 
 export const actions = {
-  async fetchLatestList({ commit, state }, params) {
+  async fetchNextListChunk({ commit, state }, params) {
     const res = await this.$axios.get(process.env.API + '/notification', {
       params: {
         context: state.context

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -60,7 +60,7 @@ export const mutations = {
 }
 
 export const getters = {
-  list: state => {
+  getCurrentList: state => {
     return state.list
   },
 
@@ -68,13 +68,13 @@ export const getters = {
     return state.context
   },
 
-  count: state => {
+  getCurrentCount: state => {
     return state.count
   }
 }
 
 export const actions = {
-  async list({ commit, state }, params) {
+  async fetchLatestList({ commit, state }, params) {
     const res = await this.$axios.get(process.env.API + '/notification', {
       params: {
         context: state.context
@@ -90,7 +90,7 @@ export const actions = {
     }
   },
 
-  async count({ commit, state, rootGetters }, params) {
+  async updateNotificationCount({ commit, state, rootGetters }, params) {
     // Check if we're logged in - no point checking for notifications if we're not.
     const me = rootGetters['auth/user']
 


### PR DESCRIPTION
Whilst thinking about a refactor of the default.vue layout I've been looking at moving notifications out into a component.  Whilst doing this I've been struggling to work out what is going on and I think this might be partly due to the naming of some of the store methods.  For example there is a getter and an action both called "count".  One returns the current fetched count and the other actually gets the latest count.
Because of this I've tried to rename a few of the methods to better reflect their purpose.  So far I've just updated it in the store code and not where it is used so we can start a discussion.