### PR TITLE
Remove the unnecessary alt attribute

### DIFF
--- a/components/ChatMessageCompleted.vue
+++ b/components/ChatMessageCompleted.vue
@@ -10,7 +10,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"
@@ -38,7 +38,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"

--- a/components/ChatMessageImage.vue
+++ b/components/ChatMessageImage.vue
@@ -11,7 +11,7 @@
                 rounded
                 thumbnail
                 class="chatimage"
-                alt="Chat image"
+                generator-unable-to-provide-required-alt=""
                 :src="chatmessage.image.path"
                 @error.native="brokenImage"
               />
@@ -29,7 +29,7 @@
               rounded
               thumbnail
               class="chatimage"
-              alt="Chat image"
+              generator-unable-to-provide-required-alt=""
               :src="chatmessage.image.path"
               @error.native="brokenImage"
             />

--- a/components/ChatMessageInterested.vue
+++ b/components/ChatMessageInterested.vue
@@ -10,7 +10,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"
@@ -55,7 +55,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"

--- a/components/ChatMessagePromised.vue
+++ b/components/ChatMessagePromised.vue
@@ -10,7 +10,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"
@@ -42,7 +42,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"

--- a/components/ChatMessageReneged.vue
+++ b/components/ChatMessageReneged.vue
@@ -10,7 +10,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"
@@ -42,7 +42,7 @@
                 class="float-right"
                 rounded
                 thumbnail
-                alt="Item photo"
+                generator-unable-to-provide-required-alt=""
                 lazy
                 :src="refmsg.attachments[0].paththumb"
                 width="70px"

--- a/components/CommunityEvent.vue
+++ b/components/CommunityEvent.vue
@@ -98,7 +98,7 @@
                 rounded
                 thumbnail
                 class="square float-right"
-                alt="Event photo"
+                generator-unable-to-provide-required-alt=""
                 title="Event photo"
               />
             </b-col>

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -26,7 +26,7 @@
               rounded
               fluid-grow
               class="attachment p-0 square"
-              alt="Item picture"
+              generator-unable-to-provide-required-alt=""
               title="Item picture"
               :src="attachments[0].paththumb"
             />
@@ -118,7 +118,7 @@
                 rounded
                 thumbnail
                 class="attachment p-0 square nottoobig"
-                alt="Item picture"
+                generator-unable-to-provide-required-alt=""
                 title="Item picture"
                 :src="attachments[0].paththumb"
               />

--- a/components/ModImage.vue
+++ b/components/ModImage.vue
@@ -5,7 +5,7 @@
       center
       class="img-thumbnail square"
       :src="attachment.path"
-      alt="Message photo "
+      generator-unable-to-provide-required-alt=""
     />
     <!--    TODO Modal to zoom, rotate, delete-->
   </span>

--- a/components/MyMessage.vue
+++ b/components/MyMessage.vue
@@ -71,7 +71,7 @@
                     rounded
                     thumbnail
                     class="attachment p-0 square mb-1"
-                    alt="Item picture"
+                    generator-unable-to-provide-required-alt=""
                     title="Item picture"
                     :src="message.attachments[0].paththumb"
                   />

--- a/components/NewsAboutMe.vue
+++ b/components/NewsAboutMe.vue
@@ -30,7 +30,7 @@
       :id="'photoModal-' + newsfeed.id"
       ref="photoModal"
       title="ChitChat Photo"
-      alt="ChitChat Photo"
+      generator-unable-to-provide-required-alt=""
       size="lg"
       no-stacking
       ok-only

--- a/components/NewsAlert.vue
+++ b/components/NewsAlert.vue
@@ -33,7 +33,7 @@
       :id="'photoModal-' + newsfeed.id"
       ref="photoModal"
       title="ChitChat Photo"
-      alt="ChitChat Photo"
+      generator-unable-to-provide-required-alt=""
       size="lg"
       no-stacking
       ok-only

--- a/components/NewsMessage.vue
+++ b/components/NewsMessage.vue
@@ -24,7 +24,7 @@
       :id="'photoModal-' + newsfeed.id"
       ref="photoModal"
       title="ChitChat Photo"
-      alt="ChitChat Photo"
+      generator-unable-to-provide-required-alt=""
       size="lg"
       no-stacking
       ok-only

--- a/components/NewsPhotoModal.vue
+++ b/components/NewsPhotoModal.vue
@@ -41,7 +41,7 @@
           :src="src + '?' + cacheBust"
           rounded
           fluid
-          alt="ChitChat Photo"
+          generator-unable-to-provide-required-alt=""
           @error.native="brokenImage"
         />
       </div>

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -28,7 +28,7 @@
                     v-b-modal="'photoModal-' + replyid"
                     rounded
                     class="clickme replyphoto"
-                    alt="ChitChat photo"
+                    generator-unable-to-provide-required-alt=""
                     :src="reply.image.paththumb"
                     @error.native="brokenImage"
                   />
@@ -134,7 +134,7 @@
       :id="'photoModal-' + replyid"
       ref="photoModal"
       title="ChitChat Photo"
-      alt="ChitChat Photo"
+      generator-unable-to-provide-required-alt=""
       size="lg"
       no-stacking
       ok-only

--- a/components/Story.vue
+++ b/components/Story.vue
@@ -38,7 +38,7 @@
       :id="'photoModal-' + story.photo.id"
       ref="photoModal"
       title="Story Photo"
-      alt="Story Photo"
+      generator-unable-to-provide-required-alt=""
       size="lg"
       no-stacking
       ok-only

--- a/components/VolunteerOpportunity.vue
+++ b/components/VolunteerOpportunity.vue
@@ -123,7 +123,7 @@
                 rounded
                 thumbnail
                 class="square float-right"
-                alt="Opportunity photo"
+                generator-unable-to-provide-required-alt=""
                 title="Opportunity photo"
               />
             </b-col>


### PR DESCRIPTION
Ok this is an interesting one....

I’ve been having a think about alt text for user uploaded images after seeing your recent checkin to modImage.vue.  Basically in your checkin, all photos will have alttext of “Message photo”.  Generally this isn’t helpful at all to someone that can’t see the image.  It doesn’t provide any useful information.  

Previously I would have suggested that these type of images have empty alt text. i.e. alt=”” but after having a further read on the subject I think I’ve changed my mind.

If the image conveys information then it should have alt text. Setting alttext to be an empty string states that the image doesn’t provide any extra useful information. e.g. just an icon on a cancel button for example.  In the case that the user has uploaded an image then the information is providing useful information but it is just not possible to provide alttext. We aren't going to get the Freeglers to add in alt text to each photo. In this case the alttext attribute should be missed out.

Here are some links that discuss this:

https://www.joedolson.com/2015/03/are-alt-attributes-required-always/

https://www.w3.org/TR/2017/REC-html52-20171214/semantics-embedded-content.html#guidance-for-markup-generators

From this link it states that “omitting this attribute indicates that the image is a key part of the content but no textual equivalent is available.  Setting this attribute to the empty string indicates that this image is not a key part of the content; non-visual browsers may omit it from rendering.”

If you add the attribute "generator-unable-to-provide-required-alt" then it can signal to conformance checkers that the image is ok.
