### PR TITLE
Tweak the danger notice message colors

### DIFF
--- a/assets/css/_color-vars.scss
+++ b/assets/css/_color-vars.scss
@@ -44,7 +44,10 @@ $color-yellow-3: #674E04; // Only used for notice warning message
 
 $color-orange--dark: #FF8C00;
 
+$color-red--lighter: #F8D7DA; // Only used for notice warning message
+$color-red--light: #F5C6CB; // Only used for notice warning message
 $color-red: #FF0000;
+$color-red--dark: #721C24; // Only used for notice warning message
 
 $color-white: #FFF;
 $color-black: #000;

--- a/components/NoticeMessage.vue
+++ b/components/NoticeMessage.vue
@@ -44,8 +44,8 @@ export default {
 }
 
 .notice--danger {
-  background-color: $color-red;
-  border-color: $color-red;
-  color: $color-white;
+  background-color: $color-red--lighter;
+  border-color: $color-red--light;
+  color: $color-red--dark;
 }
 </style>


### PR DESCRIPTION
Not sure where I got the colours from before but now these are the same colours as the bootstrap danger colours.