### PR TITLE
Enhancements/add common profile header

### DIFF
--- a/components/ProfileHeader.vue
+++ b/components/ProfileHeader.vue
@@ -1,0 +1,71 @@
+<template>
+  <b-media>
+    <template slot="aside">
+      <ProfileImage :image="user.profile.url" class="mb-1 mt-1 inline" is-thumbnail size="xl" />
+    </template>
+    <b-media-body class="align-top d-flex justify-content-between profile__info">
+      <div>
+        <h4 class="d-inline-block">
+          {{ user.displayname }}
+        </h4>
+        <div>
+          <div class="text-muted">
+            <span class="glyphicon glyphicon-heart" /> Freegler since {{ user.added | dateonly }}.
+          </div>
+          <span v-if="user.settings.showmod" class="text-muted">
+            <v-icon name="leaf" /> Freegle Volunteer
+          </span>
+        </div>
+      </div>
+      <div>
+        <div class="small text-faded mb-1 text-left text-lg-right">
+          #{{ user.id }}
+        </div>
+        <div class="d-flex flex-row flex-lg-column align-items-baseline">
+          <ChatButton
+            v-if="user.id !== myid"
+            :userid="user.id"
+            size="sm"
+            title="Message"
+            class="mb-1 order-1 order-lg-0 align-self-lg-center"
+          />
+          <ratings :id="user.id" size="sm" class="pt-1 mr-2 mr-lg-0 d-block" />
+        </div>
+      </div>
+    </b-media-body>
+  </b-media>
+</template>
+
+<script>
+import ProfileImage from '~/components/ProfileImage'
+import ChatButton from '~/components/ChatButton'
+import Ratings from '~/components/Ratings'
+
+export default {
+  components: {
+    ProfileImage,
+    ChatButton,
+    Ratings
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/_functions';
+@import 'bootstrap/scss/_variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+
+.profile__info {
+  flex-direction: column;
+
+  @include media-breakpoint-up(lg) {
+    flex-direction: row;
+  }
+}
+</style>

--- a/components/ProfileImage.vue
+++ b/components/ProfileImage.vue
@@ -106,20 +106,6 @@ export default {
 }
 
 .profile--xl {
-  width: 93px;
-  height: 93px;
-  min-width: 93px;
-  min-height: 93px;
-
-  @include media-breakpoint-up(md) {
-    width: 93px;
-    height: 93px;
-    min-width: 93px;
-    min-height: 93px;
-  }
-}
-
-.profile--xxl {
   width: 75px;
   height: 75px;
   min-width: 75px;

--- a/components/ProfileModal.vue
+++ b/components/ProfileModal.vue
@@ -7,41 +7,8 @@
     no-stacking
   >
     <template slot="modal-header">
-      <div class="m-0 coverphoto">
-        <b-media>
-          <template slot="aside">
-            <ProfileImage :image="user.profile.url" class="mr-1 ml-1 mb-1 mt-1 inline" is-thumbnail size="xl" />
-          </template>
-          <b-media-body class="align-top">
-            <h4 class="d-inline-block w-100 overflow-hidden">
-              <span class="small">
-                <span class="small text-faded float-right mr-1 d-none d-sm-inline-block">#{{ id }}</span>
-              </span>
-              {{ user.displayname }}
-              <br>
-              <div class="small">
-                <span class="small">
-                  Freegler since {{ user.added | dateonly }}.
-                </span>
-              </div>
-              <span v-if="user.settings.showmod" class="small text-muted">
-                <span class="small">
-                  <v-icon name="leaf" /> Freegle Volunteer
-                </span>
-              </span>
-              <ChatButton
-                :userid="id"
-                size="sm"
-                title="Message"
-                variant="white"
-                :disabled="user.id === myid ? 'true' : undefined"
-                class="mb-1 mt-1"
-                @click="hide"
-              />
-              <ratings :id="user.id" size="sm" class="pt-1 mt-1" />
-            </h4>
-          </b-media-body>
-        </b-media>
+      <div class="coverphoto">
+        <profile-header :user="user" class="flex-grow-1 px-3 py-2" />
       </div>
     </template>
     <template slot="default">
@@ -128,20 +95,16 @@
 
 <script>
 import twem from '~/assets/js/twem'
-import ProfileImage from '~/components/ProfileImage'
+import ProfileHeader from '~/components/ProfileHeader'
 
-const Ratings = () => import('~/components/Ratings')
 const ReplyTime = () => import('~/components/ReplyTime')
-const ChatButton = () => import('~/components/ChatButton.vue')
 const NoticeMessage = () => import('~/components/NoticeMessage')
 
 export default {
   components: {
-    Ratings,
     ReplyTime,
-    ChatButton,
     NoticeMessage,
-    ProfileImage
+    ProfileHeader
   },
   props: {
     id: {
@@ -198,17 +161,9 @@ export default {
 }
 
 .coverphoto {
-  height: 100px !important;
+  min-height: 100px !important;
   width: 100% !important;
   background-image: url('~static/wallpaper.png');
-}
-
-.coverprofilecircle {
-  width: 100px;
-  height: 100px;
-  background-color: $color-gray--base;
-  border-radius: 50%;
-  /*margin: 10px;*/
 }
 
 .covername {

--- a/pages/profile/_id.vue
+++ b/pages/profile/_id.vue
@@ -3,43 +3,7 @@
     <div v-if="user" class="profile__wrapper">
       <b-card variant="white" border-variant="success" class="mt-1">
         <b-card-body class="p-0">
-          <div class="m-0">
-            <b-media>
-              <template slot="aside">
-                <ProfileImage :image="user.profile.url" class="mb-1 mt-1 inline" is-thumbnail size="xl" />
-              </template>
-              <b-media-body class="align-top d-flex justify-content-between profile__info">
-                <div>
-                  <h4 class="d-inline-block">
-                    {{ user.displayname }}
-                  </h4>
-                  <div>
-                    <div class="text-muted">
-                      <span class="glyphicon glyphicon-heart" /> Freegler since {{ user.added | dateonly }}.
-                    </div>
-                    <span v-if="user.settings.showmod" class="text-muted">
-                      <v-icon name="leaf" /> Freegle Volunteer
-                    </span>
-                  </div>
-                </div>
-                <div>
-                  <div class="small text-faded mb-1 text-left text-lg-right">
-                    #{{ id }}
-                  </div>
-                  <div class="d-flex flex-row flex-lg-column align-items-baseline">
-                    <ChatButton
-                      v-if="user.id !== myid"
-                      :userid="user.id"
-                      size="sm"
-                      title="Message"
-                      class="mb-1 order-1 order-lg-0 align-self-lg-center"
-                    />
-                    <ratings :id="user.id" size="sm" class="pt-1 mr-2 mr-lg-0 d-block" />
-                  </div>
-                </div>
-              </b-media-body>
-            </b-media>
-          </div>
+          <profile-header :user="user" class="m-0" />
         </b-card-body>
       </b-card>
       <b-card v-if="aboutme" variant="white" class="mt-2">
@@ -147,20 +111,16 @@ import NoticeMessage from '../../components/NoticeMessage'
 import twem from '~/assets/js/twem'
 import loginOptional from '@/mixins/loginOptional.js'
 
-import Ratings from '~/components/Ratings'
 import ReplyTime from '~/components/ReplyTime'
 import Message from '~/components/Message.vue'
-import ChatButton from '~/components/ChatButton'
-import ProfileImage from '~/components/ProfileImage'
+import ProfileHeader from '~/components/ProfileHeader'
 
 export default {
   components: {
     NoticeMessage,
-    Ratings,
     ReplyTime,
     Message,
-    ChatButton,
-    ProfileImage
+    ProfileHeader
   },
   mixins: [loginOptional],
   props: {},
@@ -247,12 +207,6 @@ export default {
 @import 'bootstrap/scss/_variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
 
-.coverphoto {
-  height: 100px !important;
-  width: 100% !important;
-  background-image: url('~static/wallpaper.png');
-}
-
 .covername {
   left: 108px;
   position: absolute;
@@ -272,14 +226,6 @@ export default {
     margin: 0 auto;
     padding-left: 0;
     padding-right: 0;
-  }
-}
-
-.profile__info {
-  flex-direction: column;
-
-  @include media-breakpoint-up(lg) {
-    flex-direction: row;
   }
 }
 </style>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -51,7 +51,7 @@
                         :image="profileurl"
                         class="mr-1 mb-1 mt-1 inline"
                         is-thumbnail
-                        size="xxl"
+                        size="xl"
                       />
                       <br>
                       <OurToggle


### PR DESCRIPTION
This PR:
- Sorts out the modal profile popup header for all screensizes. 
- Uses a common header for the modal and non-modal profile views
- Removes the odd-size profile image option so the settings and profile headers both use 100px.
