### PR TITLE
Correct the layout of these pages on mobile

### DIFF
--- a/pages/communityevents/_id.vue
+++ b/pages/communityevents/_id.vue
@@ -10,16 +10,12 @@
             events, do please add them here so that other people can get involved.
           </NoticeMessage>
           <p>These are local events, posted by other freeglers like you.</p>
-          <b-row class="mb-3">
-            <b-col>
-              <groupSelect v-if="me" v-model="groupid" class="float-left" all />
-            </b-col>
-            <b-col>
-              <b-btn variant="success" class="float-right" @click="showEventModal">
-                <v-icon name="plus" /> Add an event
-              </b-btn>
-            </b-col>
-          </b-row>
+          <div class="d-flex justify-content-between mb-3">
+            <groupSelect v-if="me" v-model="groupid" class="pr-2" all />
+            <b-btn variant="success" class="float-right" @click="showEventModal">
+              <v-icon name="plus" /> Add an event
+            </b-btn>
+          </div>
         </div>
         <div v-for="event in events" :key="'event-' + event.id" class="mt-2">
           <CommunityEvent v-if="!event.pending" :summary="false" :event="event" />

--- a/pages/volunteerings/_id.vue
+++ b/pages/volunteerings/_id.vue
@@ -6,16 +6,12 @@
           <h1>Volunteer Opportunities</h1>
           <CovidWarning />
           <p>Are you a charity or good cause that needs volunteers? Ask our lovely community of freeglers to help.</p>
-          <b-row class="mb-3">
-            <b-col>
-              <groupSelect v-if="me" v-model="groupid" class="float-left" all />
-            </b-col>
-            <b-col>
-              <b-btn variant="success" class="float-right" @click="showEventModal">
-                <v-icon name="plus" /> Add an opportunity
-              </b-btn>
-            </b-col>
-          </b-row>
+          <div class="d-flex justify-content-between mb-3">
+            <groupSelect v-if="me" v-model="groupid" class="pr-2" all />
+            <b-btn variant="success" class="float-right" @click="showEventModal">
+              <v-icon name="plus" /> Add an opportunity
+            </b-btn>
+          </div>
         </div>
         <div v-for="volunteering in volunteerings" :key="'volunteering-' + volunteering.id" class="mt-2">
           <VolunteerOpportunity v-if="!volunteering.pending" :summary="false" :volunteering="volunteering" />


### PR DESCRIPTION
This resolves the bootstrap negative margin spacing issues on smaller screens for the events and .  

In reality these whole pages really need some kind of gutters down the side and the community dropdown should probably be on it's own line and there isn't really enough room to display it next to the button.  But that's another issue...