### PR TITLE
Fix the active nav selection colour

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -683,11 +683,16 @@ html {
   padding-bottom: 0px !important;
 }
 
-nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
+nav .navbar-nav li a.nuxt-link-active {
   color: $color-white-opacity-50 !important;
 }
 
-.navbar-dark .navbar-nav .nav-link {
+.nuxt-link-active .nav-item__text {
+  border-bottom: 1px solid white;
+  padding: 2px;
+}
+
+::v-deep .nav-link {
   color: $color-white !important;
 
   &:hover,
@@ -769,19 +774,6 @@ nav .navbar-nav li a.nuxt-link-active[data-v-314f53c6] {
 
 .ourBack {
   background-color: $colour-success !important;
-}
-
-nav .navbar-nav li a {
-  color: $color-gray--light !important;
-}
-
-nav .navbar-nav li a.nuxt-link-active {
-  color: $color-white !important;
-}
-
-.nuxt-link-active .nav-item__text {
-  border-bottom: 1px solid white;
-  padding: 2px;
 }
 
 .navbar-brand a {


### PR DESCRIPTION
This should fix the issue where the active page wasn't highlighted on mobile devices.  The classes were a bit weird so I've just removed some and removed the manual use of the data- attribute.  I've tried this on Chrome and on a couple of mobile devices in browserstack and it looks fine.