### PR TITLE
Adjust the layout and size of the contact options so it fits on mobile

### DIFF
--- a/pages/help.vue
+++ b/pages/help.vue
@@ -398,11 +398,15 @@
         </h1>
         <p>If your question isn't answered above, or you wish to compliment or complain, then you can <b>contact your volunteer team</b>, who will be happy to hear whether Freegle is doing a great job or needs changing.</p>
         <h5>Which Freegle community do you need help with?</h5>
-        <div v-if="loggedIn">
-          <GroupRememberSelect v-model="contactGroupId" remember="contactmods" class="mt-2 mb-2" />
-          <br>
-          <ChatButton :groupid="contactGroupId" size="lg" title="Contact community volunteers" variant="success" class="mt-2 mb-2" />
-        </div>
+        <b-card no-body>
+          <b-card-body class="text-left p-2">
+            <div v-if="loggedIn">
+              <GroupRememberSelect v-model="contactGroupId" remember="contactmods" class="mt-2 mb-2" />
+              <br>
+              <ChatButton :groupid="contactGroupId" size="md" title="Contact community volunteers" variant="success" class="mt-2 mb-2" />
+            </div>
+          </b-card-body>
+        </b-card>
         <div class="text-muted">
           <hr>
           <p>


### PR DESCRIPTION
Currently the "contact community volunteers" button on the help page is causing layout issues on mobile.  I've shrunk the button down in size a bit and added a border around the selection to tie the form control and action button together.