### PR TITLE
If we are displaying a region then make sure it's the map focus

### DIFF
--- a/components/ExploreMap.vue
+++ b/components/ExploreMap.vue
@@ -353,16 +353,38 @@ export default {
     idle() {
       const google = gmapApi()
 
-      if ((this.swlat || this.swlng) && !this.initialBounds) {
-        // We've been asked to set the bounds of the map.
-        this.initialBounds = true
-        this.$refs.gmap.$mapObject.fitBounds(
-          new google.maps.LatLngBounds(
-            new google.maps.LatLng(this.swlat, this.swlng),
-            new google.maps.LatLng(this.nelat, this.nelng)
-          ),
-          0
-        )
+      // The focus and zoom on the map should only be set on it's inital load.
+      // The initialBounds property controls that
+      if (!this.initialBounds) {
+        if (this.swlat || this.swlng) {
+          // Specific bounds have been passed in so use them
+          this.initialBounds = true
+
+          this.$refs.gmap.$mapObject.fitBounds(
+            new google.maps.LatLngBounds(
+              new google.maps.LatLng(this.swlat, this.swlng),
+              new google.maps.LatLng(this.nelat, this.nelng)
+            ),
+            0
+          )
+        } else if (this.region && this.groupsInBounds) {
+          // We are displaying a specific region so zoom to it
+          this.initialBounds = true
+
+          const latlngbounds = new google.maps.LatLngBounds()
+
+          if (this.groupsInBounds) {
+            this.groupsInBounds.forEach(group => {
+              if (group.onmap) {
+                latlngbounds.extend(
+                  new google.maps.LatLng(group.lat, group.lng)
+                )
+              }
+            })
+
+            this.$refs.gmap.$mapObject.fitBounds(latlngbounds)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
So I've just kept to the same method that you have used here for updating the map.  i.e. using the idle event.  "The internet" seem to set up a use-once event handler on idle instead but I think  I prefer what you've done here.

So basically I've just said that if you pass in a region then loop through the list of groups to get the bounds and then call fitBounds.  Pretty much the same as what you did previously.