### PR TITLE
Tweaks to the layout on group header

### DIFF
--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -31,12 +31,14 @@
       </div>
       <div class="mt-2 group__buttons">
         <div class="button__items">
+          <!--
           <b-button class="mb-1" variant="white" :href="'mailto:' + modsemail">
             <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
           </b-button>
           <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
             <GroupShowMod v-for="mod in group.showmods" :key="'showmod-' + mod.id" :modtoshow="mod" class="ml-1" />
           </div>
+        -->
           <b-button v-if="!amAMember" class="mb-1 ml-1" variant="success" @click="join">
             <v-icon v-if="joiningOrLeaving" name="sync" class="fa-spin" />
             <v-icon v-else name="plus" />&nbsp;
@@ -49,7 +51,7 @@
         </div>
       </div>
     </div>
-    <b-row>
+    <b-row class="mb-4">
       <b-col class="group-description">
         <p v-if="!group.description">
           Give and get stuff for free with {{ group.namedisplay }}.  Offer things you don't need, and ask for things you'd like.  Don't just recycle - reuse with Freegle!
@@ -58,6 +60,29 @@
         <span v-if="group.description" v-html="group.description"/>
       </b-col>
     </b-row>
+    <b-card>
+      <h2 style="font-size:16px">
+        You can contact our lovely local volunteers here
+      </h2>
+      <b-button class="mb-2" variant="white" :href="'mailto:' + modsemail">
+        <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
+      </b-button>
+      <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
+        <GroupShowMod v-for="mod in group.showmods" :key="'showmod-' + mod.id" :modtoshow="mod" class="ml-1" />
+      </div>
+    </b-card>
+    <div class="">
+      <hr>
+      <h2 style="font-size:16px">
+        You can contact our lovely local volunteers here
+      </h2>
+      <b-button class="mb-2" variant="white" :href="'mailto:' + modsemail">
+        <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
+      </b-button>
+      <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
+        <GroupShowMod v-for="mod in group.showmods" :key="'showmod-' + mod.id" :modtoshow="mod" class="ml-1" />
+      </div>
+    </div>
     <div v-if="group.sponsors" class="d-flex flex-wrap justify-content-between">
       <b-card v-for="sponsor in group.sponsors" :key="'sponsor-' + sponsor.id" no-body>
         <b-card-body class="d-flex p-1">

--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -31,14 +31,6 @@
       </div>
       <div class="mt-2 group__buttons">
         <div class="button__items">
-          <!--
-          <b-button class="mb-1" variant="white" :href="'mailto:' + modsemail">
-            <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
-          </b-button>
-          <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
-            <GroupShowMod v-for="mod in group.showmods" :key="'showmod-' + mod.id" :modtoshow="mod" class="ml-1" />
-          </div>
-        -->
           <b-button v-if="!amAMember" class="mb-1 ml-1" variant="success" @click="join">
             <v-icon v-if="joiningOrLeaving" name="sync" class="fa-spin" />
             <v-icon v-else name="plus" />&nbsp;
@@ -60,12 +52,12 @@
         <span v-if="group.description" v-html="group.description"/>
       </b-col>
     </b-row>
-    <div class="">
+    <div>
       <hr>
-      <h2 style="font-size:16px">
+      <h2 class="group-volunteers mb-3">
         You can contact our lovely local volunteers here:
       </h2>
-      <b-button class="mb-2" variant="white" :href="'mailto:' + modsemail">
+      <b-button class="mb-3" variant="white" :href="'mailto:' + modsemail">
         <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
       </b-button>
       <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
@@ -274,23 +266,23 @@ export default {
   flex-direction: row;
 
   @include media-breakpoint-up(sm) {
-    flex-direction: row;
     justify-content: flex-start;
   }
 
   @include media-breakpoint-up(md) {
-    flex-direction: row;
     justify-content: flex-end;
   }
 
   @include media-breakpoint-up(lg) {
-    flex-direction: row;
     justify-content: flex-start;
   }
 
   @include media-breakpoint-up(xl) {
-    flex-direction: row;
     justify-content: flex-end;
   }
+}
+
+.group-volunteers {
+  font-size: 16px;
 }
 </style>

--- a/components/GroupHeader.vue
+++ b/components/GroupHeader.vue
@@ -60,21 +60,10 @@
         <span v-if="group.description" v-html="group.description"/>
       </b-col>
     </b-row>
-    <b-card>
-      <h2 style="font-size:16px">
-        You can contact our lovely local volunteers here
-      </h2>
-      <b-button class="mb-2" variant="white" :href="'mailto:' + modsemail">
-        <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers
-      </b-button>
-      <div v-if="group.showmods && group.showmods.length" class="d-flex flex-wrap justify-content-start">
-        <GroupShowMod v-for="mod in group.showmods" :key="'showmod-' + mod.id" :modtoshow="mod" class="ml-1" />
-      </div>
-    </b-card>
     <div class="">
       <hr>
       <h2 style="font-size:16px">
-        You can contact our lovely local volunteers here
+        You can contact our lovely local volunteers here:
       </h2>
       <b-button class="mb-2" variant="white" :href="'mailto:' + modsemail">
         <v-icon name="question-circle" />&nbsp;Contact&nbsp;volunteers


### PR DESCRIPTION
Thought I'd add this in here for discussion.

I've moved the volunteer avatars and the button below.  Currently there are two options where one uses the bootstrap card and another with just a line break.

Thoughts?