### PR TITLE
Feature/accessible buttons  no pointer

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -138,6 +138,11 @@ button {
   white-space: nowrap;
 }
 
+.btn {
+  // Override the bootstrap default. The cursor on a button shouldn't be a pointer
+  cursor: auto !important;
+}
+
 .clickme {
   cursor: pointer;
 }

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -133,14 +133,12 @@ body.modtools {
   left: 0;
 }
 
-// Brought in from style.css
 button {
   white-space: nowrap;
-}
 
-.btn {
   // Override the bootstrap default. The cursor on a button shouldn't be a pointer
   cursor: auto !important;
+
 }
 
 .clickme {


### PR DESCRIPTION
Button elements should not have a pointer.  These are for anchor elements.

If it's got a hand pointer then you should be able to right click on it to open in a new window.  That doesn't make sense with a JavaScript button.

The bootstrap default is to give both buttons and anchors hand pointers.  Bad bootstrap.

Adam Silver is a really good authority on forms and form controls.  This is one of a series of articles he wrote on the subject.  Technically we shouldn't be styling buttons and anchors and anchors as buttons but that has become fairly standard now so it's hard to get away from.

https://adamsilver.io/articles/buttons-shouldnt-have-a-hand-cursor/