### PR TITLE
Make the searchbutton class less specific

### DIFF
--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -718,9 +718,11 @@ input[invalid='true'] {
   outline: none;
   box-shadow: none;
 }
-button.btn.searchbutton.btn-primary.btn-lg {
+
+.searchbutton {
   border-radius: 0 4px 4px 0;
 }
+
 .invalid {
   box-shadow: 0 0 0 0.2rem $color-red;
   border: none;


### PR DESCRIPTION
There is only one search button on this page and so the class targeting doesn't need to be so specific.