### PR TITLE
Feature/make showlove tabable

### DIFF
--- a/components/NewsLoveComment.vue
+++ b/components/NewsLoveComment.vue
@@ -16,10 +16,10 @@
           <v-icon name="comment" /><span class="d-none d-sm-inline">&nbsp;Reply</span>
         </b-btn>
       </li>
-      <li class="list-inline-item clickme">
-        <span v-if="newsfeed.loves" tabindex="0" class="showlove" @click="showLove">
+      <li class="list-inline-item">
+        <b-btn v-if="newsfeed.loves" variant="white" class="showlove" :aria-label="getShowLovesLabel" @click="showLove">
           <v-icon name="heart" class="text-danger" />&nbsp;{{ newsfeed.loves }}
-        </span>
+        </b-btn>
       </li>
     </ul>
     <NewsLovesModal :id="newsfeed.id" ref="loveModal" />
@@ -41,6 +41,21 @@ export default {
   data: function() {
     return {
       loving: false
+    }
+  },
+  computed: {
+    getShowLovesLabel() {
+      return (
+        'This comment has ' +
+        this.$options.filters.pluralize(
+          this.newsfeed.loves,
+          ['love', 'loves'],
+          {
+            includeNumber: true
+          }
+        ) +
+        '. Who loves this?'
+      )
     }
   },
   methods: {
@@ -78,18 +93,7 @@ export default {
 @import 'color-vars';
 
 .showlove {
+  border: none;
   padding: 3px;
-
-  &:hover {
-    border-radius: 0.2rem;
-    background-color: $color-blue--light;
-    color: white;
-  }
-
-  &:focus {
-    outline: 0;
-    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-    border-radius: 0.2rem;
-  }
 }
 </style>

--- a/components/NewsLoveComment.vue
+++ b/components/NewsLoveComment.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <ul v-if="newsfeed" class="list-unstyled list-inline d-inline-block">
+    <ul v-if="newsfeed" class="list-unstyled list-inline d-flex align-items-center">
       <li class="list-inline-item">
         <b-btn v-if="!newsfeed.loved" variant="white" size="sm" @click="love">
           <v-icon v-if="loving" name="sync" class="fa-spin text-success" />
@@ -16,8 +16,8 @@
           <v-icon name="comment" /><span class="d-none d-sm-inline">&nbsp;Reply</span>
         </b-btn>
       </li>
-      <li class="list-inline-item clickme" @click="showLove">
-        <span v-if="newsfeed.loves">
+      <li class="list-inline-item clickme">
+        <span v-if="newsfeed.loves" tabindex="0" class="showlove" @click="showLove">
           <v-icon name="heart" class="text-danger" />&nbsp;{{ newsfeed.loves }}
         </span>
       </li>
@@ -73,3 +73,23 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+
+.showlove {
+  padding: 3px;
+
+  &:hover {
+    border-radius: 0.2rem;
+    background-color: $color-blue--light;
+    color: white;
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    border-radius: 0.2rem;
+  }
+}
+</style>


### PR DESCRIPTION
The showloves button wasn't accessible by keyboard.  It's didn't have a tab stop or any focus indicator.

I've just turned it into a real button.  I'm still not sure if the accessibility side is correct yet.  The button is effectively a label showing a count and also a button to display some more info.  I think it's better than it was before but might need some tweaking in the future.