### PR TITLE
Turn the spans into proper buttons

### DIFF
--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -33,39 +33,36 @@
                     @error.native="brokenImage"
                   />
                 </div>
-                <span v-if="userid && users[userid]">
-                  <span class="text-muted small">
+                <span v-if="userid && users[userid]" class="text-muted d-flex flex-row flex-wrap align-items-center">
+                  <span class="text-muted small mr-1">
                     {{ reply.added | timeago }}
                   </span>
-                  <NewsUserInfo :user="users[userid]" />
-                  <span>
-                    &bull;<span class="text-muted small clickme" @click="replyReply">&nbsp;Reply</span>
-                  </span>
-                  <span class="text-muted small clickme">
-                    <span v-if="!reply.loved" @click="love">
-                      &bull;&nbsp;Love this
-                    </span>
-                    <span v-if="reply.loved" @click="unlove">
-                      &bull;&nbsp;Unlove this
-                    </span>
-                    <span v-if="reply.loves" class="clickme" @click="showLove">
-                      <v-icon name="heart" class="text-danger" />&nbsp;{{ reply.loves }}
-                    </span>
-                    <span v-if="parseInt(me.id) === parseInt(userid)" v-b-modal="'newsEdit-' + replyid">
-                      &bull;&nbsp;Edit
-                    </span>
-                    <span v-if="parseInt(me.id) === parseInt(userid) || mod" @click="deleteReply">
-                      &bull;&nbsp;Delete
-                    </span>
-                    <span v-if="parseInt(me.id) !== parseInt(userid)">
-                      &bull;&nbsp;
-                      <ChatButton
-                        :userid="userid"
-                        size="naked"
-                        title="Message"
-                      />
-                    </span>
-                  </span>
+                  <NewsUserInfo :user="users[userid]" class="px-1" />
+                  <b-btn variant="light" class="reply__button text-muted" @click="replyReply">
+                    Reply
+                  </b-btn>
+                  <b-btn v-if="!reply.loved" variant="light" class="reply__button text-muted" @click="love">
+                    Love this
+                  </b-btn>
+                  <b-btn v-if="reply.loved" variant="light" class="reply__button text-muted" @click="unlove">
+                    Unlove this
+                  </b-btn>
+                  <b-btn v-if="reply.loves" variant="light" class="mr-1 small text-muted showlove" @click="showLove">
+                    <v-icon name="heart" class="text-danger" />&nbsp;{{ reply.loves }}
+                  </b-btn>
+                  <b-btn v-if="parseInt(me.id) === parseInt(userid)" v-b-modal="'newsEdit-' + replyid" class="reply__button">
+                    Edit
+                  </b-btn>
+                  <b-btn v-if="parseInt(me.id) === parseInt(userid) || mod" class="reply__button" @click="deleteReply">
+                    Delete
+                  </b-btn>
+                  <ChatButton
+                    v-if="parseInt(me.id) !== parseInt(userid)"
+                    class="reply__button text-muted"
+                    :userid="userid"
+                    size="naked"
+                    title="Message"
+                  />
                 </span>
                 <NewsPreview v-if="reply.preview" :preview="reply.preview" class="mt-1" size="sm" />
                 <div v-if="reply.hidden" class="text-danger small">
@@ -583,5 +580,34 @@ export default {
 
 .image__uploaded {
   width: 100px;
+}
+
+.reply__button {
+  border: none;
+  padding: 0 2px 0 2px;
+  font-size: 12.8px;
+  margin-left: 3px;
+  margin-right: 3px;
+
+  &:before {
+    content: '\2022';
+    padding-right: 2px;
+  }
+}
+
+.showlove {
+  border: none;
+  padding: 3px;
+  font-size: 12.8px;
+}
+
+::v-deep .fa-icon {
+  margin-bottom: 1px;
+}
+
+::v-deep .btn {
+  font-size: 12.8px;
+  color: #6c757d;
+  padding: 0 2px 0 2px;
 }
 </style>


### PR DESCRIPTION
Use buttons rather than spans for the news reply options.  Previously they didn't have tabstops or hovers.

All the options on this row are slightly different at the moment.  The location has one type of border (This is actually an anchor).  The message buttons don't have any focus at all.  This change at least makes it accessible and we can tidy it further later.  I need to do something about the message button too but this is generic so will need more though.  Once that is done then I'll look into making it more standard across the whole section.