### PR TITLE
Feature/accessible chat button

### DIFF
--- a/components/ChatButton.vue
+++ b/components/ChatButton.vue
@@ -1,12 +1,12 @@
 <template>
   <span>
-    <span v-if="size === 'naked'">
-      <span class="d-none d-sm-inline-block" @click="gotoChat(true)">
+    <span v-if="naked">
+      <b-btn :variant="variant" :size="size" class="d-none d-sm-inline-block" @click="gotoChat(true)">
         {{ title }}
-      </span>
-      <span class="d-inline-block d-sm-none" @click="gotoChat(false)">
+      </b-btn>
+      <b-btn :variant="variant" :size="size" class="d-inline-block d-sm-none" @click="gotoChat(false)">
         {{ title }}
-      </span>
+      </b-btn>
     </span>
     <span v-else>
       <b-btn :size="size" :variant="variant" class="d-none d-sm-inline" @click="gotoChat(true)">
@@ -56,6 +56,11 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    naked: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   methods: {

--- a/components/ChatButton.vue
+++ b/components/ChatButton.vue
@@ -1,29 +1,20 @@
 <template>
   <span>
-    <span v-if="naked">
-      <b-btn :variant="variant" :size="size" class="d-none d-sm-inline-block" @click="gotoChat(true)">
+    <b-btn :size="size" :variant="variant" class="d-none d-sm-inline" @click="gotoChat(true)">
+      <v-icon v-if="showIcon" name="comments" />
+      <span v-if="title">
         {{ title }}
-      </b-btn>
-      <b-btn :variant="variant" :size="size" class="d-inline-block d-sm-none" @click="gotoChat(false)">
+      </span>
+    </b-btn>
+    <b-btn :size="size" :variant="variant" class="d-inline-block d-sm-none" @click="gotoChat(false)">
+      <v-icon v-if="showIcon" name="comments" />
+      <span v-if="title">
         {{ title }}
-      </b-btn>
-    </span>
-    <span v-else>
-      <b-btn :size="size" :variant="variant" class="d-none d-sm-inline" @click="gotoChat(true)">
-        <v-icon name="comments" />
-        <span v-if="title">
-          {{ title }}
-        </span>
-      </b-btn>
-      <b-btn :size="size" :variant="variant" class="d-inline-block d-sm-none" @click="gotoChat(false)">
-        <v-icon name="comments" />
-        <span v-if="title">
-          {{ title }}
-        </span>
-      </b-btn>
-    </span>
+      </span>
+    </b-btn>
   </span>
 </template>
+
 <script>
 export default {
   props: {
@@ -57,10 +48,10 @@ export default {
       required: false,
       default: null
     },
-    naked: {
+    showIcon: {
       type: Boolean,
       required: false,
-      default: false
+      default: true
     }
   },
   methods: {

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -63,7 +63,7 @@
                     size="sm"
                     title="Message"
                     variant="light"
-                    naked="true"
+                    :show-icon="false"
                   />
                 </span>
                 <NewsPreview v-if="reply.preview" :preview="reply.preview" class="mt-1" size="sm" />

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -60,8 +60,10 @@
                     v-if="parseInt(me.id) !== parseInt(userid)"
                     class="reply__button text-muted"
                     :userid="userid"
-                    size="naked"
+                    size="sm"
                     title="Message"
+                    variant="light"
+                    naked="true"
                   />
                 </span>
                 <NewsPreview v-if="reply.preview" :preview="reply.preview" class="mt-1" size="sm" />


### PR DESCRIPTION
Turn the "naked" message button into an actual button so it can be accessed by keyboard and screen readers etc.

I've removed the high-jacking of the size prop for "naked" and passed in separate prop to use to specify no icon. That way we can use the standard bootstrap variant and size props to set up different styles. The naked version is only used in one place so I've defaulted the component to have an icon so I don't need to change it in loads of places.

There are still a few niggles with this section like the bullet is in some of the hovers but not others. I'll see if I can make some more improvements without too much work.  These options would be more accessible if they were in a "ul" for example but that might involve too much refactoring for now.