### PR TITLE
Only target the specific reply buttons

### DIFF
--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -33,7 +33,7 @@
                     @error.native="brokenImage"
                   />
                 </div>
-                <span v-if="userid && users[userid]" class="text-muted d-flex flex-row flex-wrap align-items-center">
+                <span v-if="userid && users[userid]" class="text-muted d-flex flex-row flex-wrap align-items-center options-section">
                   <span class="text-muted small mr-1">
                     {{ reply.added | timeago }}
                   </span>
@@ -607,7 +607,7 @@ export default {
   margin-bottom: 1px;
 }
 
-::v-deep .btn {
+.options-section ::v-deep .btn {
   font-size: 12.8px;
   color: #6c757d;
   padding: 0 2px 0 2px;


### PR DESCRIPTION
This should resolve the edit modal issue.  I can't work out how to target an element with two classes using v-deep so I've just added an unused parent class to fix it for now.