### PR TITLE
Fixes to make the light button work in other cases

### DIFF
--- a/assets/css/_color-vars.scss
+++ b/assets/css/_color-vars.scss
@@ -16,6 +16,7 @@ $color-green--dark: #3B8070;
 $color-green--darker: #008000;
 $color-green--bright: #28A745;
 
+$color-gray--normal: #6C757D;
 $color-gray--faded: #6C757D70; // Including alpha
 $color-gray--lighter: #F5F5F5;
 $color-gray--light: #CDCDCD;

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -117,6 +117,18 @@
   -webkit-font-smoothing: antialiased;
 }
 
+.btn-light {
+  color: $color-gray--normal;
+  background-color: inherit;
+  font-size: 0.8rem;
+  padding: 0 2px 0 2px;
+  border: none;
+
+  &:hover {
+    color: $color-gray--normal;
+  }
+}
+
 .text-success {
   color: $colour-success !important;
 }

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -33,7 +33,7 @@
                     @error.native="brokenImage"
                   />
                 </div>
-                <span v-if="userid && users[userid]" class="text-muted d-flex flex-row flex-wrap align-items-center options-section">
+                <span v-if="userid && users[userid]" class="text-muted d-flex flex-row flex-wrap align-items-center">
                   <span class="text-muted small mr-1">
                     {{ reply.added | timeago }}
                   </span>
@@ -58,7 +58,7 @@
                   </b-btn>
                   <ChatButton
                     v-if="parseInt(me.id) !== parseInt(userid)"
-                    class="reply__button text-muted"
+                    class="reply__button text-muted d-flex align-items-center"
                     :userid="userid"
                     size="sm"
                     title="Message"
@@ -585,9 +585,6 @@ export default {
 }
 
 .reply__button {
-  border: none;
-  padding: 0 2px 0 2px;
-  font-size: 12.8px;
   margin-left: 3px;
   margin-right: 3px;
 
@@ -600,16 +597,10 @@ export default {
 .showlove {
   border: none;
   padding: 3px;
-  font-size: 12.8px;
+  font-size: 0.8rem;
 }
 
 ::v-deep .fa-icon {
   margin-bottom: 1px;
-}
-
-.options-section ::v-deep .btn {
-  font-size: 12.8px;
-  color: #6c757d;
-  padding: 0 2px 0 2px;
 }
 </style>


### PR DESCRIPTION
OK so I've now created a permanent button variant for this.  I've given it a test in the areas you found problems in but I will continue some more testing this afternoon.

There is one niggle I'm found which is when you hover when the button is on the blue background it is still gray.  Trying to have a see-through button which has a context sensitive hover colour would be awkward.  The only thing I could think of would be to use some kind of filter on the background colour.  So I guess it depends on how much you hate it!