### PR TITLE
Sort out the alignment of the email fields

### DIFF
--- a/components/EmailValidator.vue
+++ b/components/EmailValidator.vue
@@ -1,33 +1,31 @@
 <template>
-  <div class="d-inline-block w-100">
-    <div :class="{ 'justify-content-around': center, 'd-flex': true }">
-      <b-form-group
-        :label="label"
-        :label-for="'email-' + uniqueid"
-        label-class="mt-0"
-      >
-        <validating-form-input
-          :id="'email-' + uniqueid"
-          :value="email"
-          type="email"
-          name="email"
-          :size="size"
-          class="email"
-          :validation="$v.email"
-          validation-enabled
-          :validation-messages="{
-            email: 'Please enter a valid email address.'
-          }"
-          :center="center"
-          autocomplete="username email"
-          @input="input"
-          @focus="focus"
-          @blur="blur"
-        />
-      </b-form-group>
-      <div v-if="suggestedDomains && suggestedDomains.length" class="text-info small">
-        Did you mean <b>{{ suggestedDomains[0] }}</b>?
-      </div>
+  <div class="d-flex flex-column">
+    <b-form-group
+      :label="label"
+      :label-for="'email-' + uniqueid"
+      label-class="mt-0"
+    >
+      <validating-form-input
+        :id="'email-' + uniqueid"
+        :value="email"
+        type="email"
+        name="email"
+        :size="size"
+        class="email"
+        :validation="$v.email"
+        validation-enabled
+        :validation-messages="{
+          email: 'Please enter a valid email address.'
+        }"
+        :center="center"
+        autocomplete="username email"
+        @input="input"
+        @focus="focus"
+        @blur="blur"
+      />
+    </b-form-group>
+    <div v-if="suggestedDomains && suggestedDomains.length" class="text-info small mb-2">
+      Did you mean <b>{{ suggestedDomains[0] }}</b>?
     </div>
   </div>
 </template>

--- a/pages/find/whoami.vue
+++ b/pages/find/whoami.vue
@@ -10,7 +10,7 @@
           <b-col class="text-muted text-center">
             <p>We need your email address to let you know when you have replies.  We won't give your email to anyone else.</p>
             <p>You will get emails from us, which you can control or turn off from Settings.</p>
-            <EmailValidator :email.sync="email" :valid.sync="emailValid" center />
+            <EmailValidator :email.sync="email" :valid.sync="emailValid" center class="align-items-center" />
           </b-col>
         </b-row>
         <transition name="fadein">

--- a/pages/give/whoami.vue
+++ b/pages/give/whoami.vue
@@ -11,7 +11,7 @@
             <b-col class="text-muted text-center">
               <p>We need your email address to let you know when you have replies.  We won't give your email to anyone else.</p>
               <p>You will get emails from us, which you can control or turn off from Settings.</p>
-              <EmailValidator :email.sync="email" :valid.sync="emailValid" center />
+              <EmailValidator :email.sync="email" :valid.sync="emailValid" center class="align-items-center" />
             </b-col>
           </b-row>
           <transition name="fadein">


### PR DESCRIPTION
See if this works for you.  I've changed the email validator to be in a column so it lays out correctly.  Most uses of it (like on the settings page) will lay out left aligned.  On the give and find pages I've aligned them centrally in the parent.