### PR TITLE
Tidy up the tab stops

### DIFF
--- a/components/CommunityEvent.vue
+++ b/components/CommunityEvent.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <b-card variant="success" no-body>
-      <b-card-title class="bg-info pl-2 mb-0 pt-2 pb-2 text-truncate">
+      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between">
         <nuxt-link :to="'/communityevent/' + item.id" class="event__link">
-          <span v-if="!summary" class="float-right small text-muted">
-            #{{ item.id }}
-          </span>
           {{ item.title }}
+        </nuxt-link>
+        <nuxt-link v-if="!summary" :to="'/communityevent/' + item.id" class="event__link small text-muted">
+          #{{ item.id }}
         </nuxt-link>
       </b-card-title>
       <b-card-body class="p-1 pt-0">

--- a/components/VolunteerOpportunity.vue
+++ b/components/VolunteerOpportunity.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <b-card variant="success" no-body>
-      <b-card-title class="bg-info pl-2 mb-0 pt-2 pb-2 text-truncate">
+      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between">
         <nuxt-link :to="'/volunteering/' + item.id" class="volunteerop__link">
-          <span v-if="!summary" class="float-right small text-muted">
-            #{{ item.id }}
-          </span>
           {{ item.title }}
+        </nuxt-link>
+        <nuxt-link v-if="!summary" :to="'/volunteering/' + item.id" class="volunteerop__link small text-muted">
+          #{{ item.id }}
         </nuxt-link>
       </b-card-title>
       <b-card-body class="p-1 pt-0">


### PR DESCRIPTION
Having the title and the id connected just seemed very weird with the distance between them.  Hovering over the title also highlighted the id which was quite confusing.  I don't think this really works so I've split them up into two.

I've tested the volunteer op when it is and isn't a summary.  I've also updated the event but I don't have any to test so would be useful to have a quick check that it works ok.