### PR TITLE
Resolve the scoping issues of the postcode styles

### DIFF
--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -635,6 +635,10 @@ export default {
   right: 48%;
 }
 
+::v-deep .postcodelist.autocomplete ul {
+  position: initial;
+}
+
 /*.autocomplete ul:before{*/
 /*content: "";*/
 /*display: block;*/

--- a/components/Postcode.vue
+++ b/components/Postcode.vue
@@ -206,8 +206,3 @@ export default {
   }
 }
 </script>
-<style scoped>
-::v-deep .autocomplete ul {
-  position: initial;
-}
-</style>


### PR DESCRIPTION
This should resolve the issue raised in slack re. the width of the postcode autocomplete.

There appears to be a difference in the scoping data- attributes when directly navigating to the give page.  I have now moved the class which is used to correct this position from the postcode component into the autocomplete component.  I think this is actually a better place for it to live as it is closer to where it is actually used and makes more sense as it overrides a property in that component anyway,