### PR TITLE
Disassociate the semantic headers from the visual aspect

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -137,6 +137,22 @@ h1, h2, h3, h4 {
   color: $colour-header !important;
 }
 
+.header--size1 {
+  font-size: 2.5rem;
+}
+
+.header--size2 {
+  font-size: 2rem;
+}
+
+.header--size3 {
+  font-size: 1.75rem;
+}
+
+.header--size4 {
+  font-size: 1.5rem;
+}
+
 div[variant="success"] .card-header {
   color: $colour-success-fg;
   background-color: $color-green--light;

--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -153,6 +153,10 @@ h1, h2, h3, h4 {
   font-size: 1.5rem;
 }
 
+.header--size5 {
+  font-size: 1.25rem;
+}
+
 div[variant="success"] .card-header {
   color: $colour-success-fg;
   background-color: $color-green--light;

--- a/components/CommunityEvent.vue
+++ b/components/CommunityEvent.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-card variant="success" no-body>
-      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between">
+      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between header--size4" :title-tag="titleTag">
         <nuxt-link :to="'/communityevent/' + item.id" class="event__link">
           {{ item.title }}
         </nuxt-link>
@@ -126,6 +126,11 @@ export default {
     item: {
       type: Object,
       required: true
+    },
+    titleTag: {
+      type: String,
+      required: false,
+      default: 'h3'
     }
   },
   data: function() {

--- a/components/CommunityFeature.vue
+++ b/components/CommunityFeature.vue
@@ -4,11 +4,11 @@
       <b-card-body class="p-0">
         <div class="p-1">
           <div class="d-flex align-items-start justify-content-between">
-            <h4>
+            <h2 class="header--size4">
               <nuxt-link :to="link" class="title__link">
                 <v-icon :name="iconName" scale="2" /> {{ title }}
               </nuxt-link>
-            </h4>
+            </h2>
             <b-btn variant="white" :aria-label="addButtonLabel" @click="showEventModal">
               <v-icon name="plus" /> Add
             </b-btn>

--- a/components/ExploreMap.vue
+++ b/components/ExploreMap.vue
@@ -7,9 +7,9 @@
         </div>
         <div v-else>
           <h1>Explore Freegle communities across the UK!</h1>
-          <h5 v-if="groupCount">
+          <p v-if="groupCount" class="community__heading">
             There are {{ groupCount }} lovely communities of freeglers across the UK. Shall we see what they're up to?
-          </h5>
+          </p>
         </div>
       </b-col>
     </b-row>
@@ -32,9 +32,9 @@
     </b-row>
     <b-row v-if="!region && regions.length" class="m-0">
       <b-col cols="12" lg="6" offset-lg="3" class="mt-2">
-        <h5 class="text-center">
+        <h2 class="text-center header--size5 community__text">
           Choose a region:
-        </h5>
+        </h2>
         <b-list-group horizontal class="flex flex-wrap justify-content-center">
           <b-list-group-item v-for="r in regions" :key="r" class="p-0 mt-2 ml-2 mr-2">
             <b-btn variant="white" :to="'/explore/region/' + r">
@@ -63,6 +63,9 @@
         </client-only>
       </b-col>
     </b-row>
+    <h2 class="sr-only">
+      List of communities
+    </h2>
     <b-row class="m-0">
       <b-col v-if="groupsInBounds.length" cols="12" lg="6" offset-lg="3" class="mt-4">
         <b-card header-bg-variant="success" header-text-variant="white" header="Here's a list of communities:">
@@ -121,9 +124,9 @@
             </client-only>
           </b-card-body>
         </b-card>
-        <h5 class="text-center mt-2">
+        <p class="text-center mt-2 header--size5 community__heading community__text">
           If there's no community for your area, would you like to start one? <a href="mailto:newgroups@ilovefreegle.org">Mail us!</a>
-        </h5>
+        </p>
         <p class="text-center">
           You can also look at our <nuxt-link to="/livemap">
             live map
@@ -370,3 +373,16 @@ export default {
   }
 }
 </script>
+
+<style>
+.community__heading {
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.community__text {
+  /* Need to override the h2 as it has higher specificity */
+  color: #212529 !important;
+}
+</style>

--- a/components/JobsTopBar.vue
+++ b/components/JobsTopBar.vue
@@ -1,7 +1,9 @@
 <template>
   <div v-if="!simple && location" class="mb-2 jobbox bg-light overflow-hidden forcewrap">
     <NoticeMessage v-if="blocked" variant="warning">
-      <h3>Please help keep Freegle running</h3>
+      <h2 class="header--size3">
+        Please help keep Freegle running
+      </h2>
       <p>
         We normally show job ads here.  It looks like you may have an AdBlocker or security software which is blocking those.
         We're not mad on ads either, but please consider donating to help us keep going:

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -3,7 +3,7 @@
     <span ref="breakpoint" class="d-inline d-sm-none" />
     <b-card class="p-0 mb-1" variant="success">
       <b-card-header :class="'pl-2 pr-2 clearfix' + (ispromised ? ' promisedfade' : '')">
-        <b-card-title class="msgsubj mb-0 d-block d-sm-none">
+        <b-card-title class="msgsubj mb-0 d-block d-sm-none header--size4" title-tag="h3">
           <div>
             <div>
               <Highlighter
@@ -54,7 +54,7 @@
             </b-button>
           </div>
         </b-card-title>
-        <b-card-title class="msgsubj mb-0 d-none d-sm-block">
+        <b-card-title class="msgsubj mb-0 d-none d-sm-block header--size4" title-tag="h3">
           <div class="d-flex justify-content-between">
             <div class="d-flex flex-column flex-grow-1">
               <Highlighter
@@ -573,12 +573,12 @@ export default {
   padding: 0px;
 }
 
-h4 {
+.header--size4 {
   color: $colour-info-fg !important;
   font-weight: bold;
 }
 
-h4.snippet {
+.header--size4.snippet {
   color: $color-black !important;
   font-weight: 500;
 }

--- a/components/Viewed.vue
+++ b/components/Viewed.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card v-if="messages && messages.length" bg-light class="recentviews">
-    <b-card-title>
+    <b-card-title title-tag="h2" class="header--size4">
       Recently Viewed
     </b-card-title>
     <div v-for="(message, index) in messages" :key="'message-' + message.id">

--- a/components/VolunteerOpportunity.vue
+++ b/components/VolunteerOpportunity.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-card variant="success" no-body>
-      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between">
+      <b-card-title class="bg-info px-2 mb-0 pt-2 pb-2 text-truncate d-flex justify-content-between header--size4" :title-tag="titleTag">
         <nuxt-link :to="'/volunteering/' + item.id" class="volunteerop__link">
           {{ item.title }}
         </nuxt-link>
@@ -158,6 +158,11 @@ export default {
     item: {
       type: Object,
       required: true
+    },
+    titleTag: {
+      type: String,
+      required: false,
+      default: 'h3'
     }
   },
   data: function() {

--- a/pages/browse/_id.vue
+++ b/pages/browse/_id.vue
@@ -1,5 +1,8 @@
 <template>
   <b-container fluid>
+    <h1 class="sr-only">
+      Browse items
+    </h1>
     <b-row class="m-0">
       <b-col cols="0" lg="3" class="d-none d-lg-block p-0 pr-1">
         <SidebarLeft :show-community-events="true" :show-bot-left="true" />
@@ -53,6 +56,9 @@
             <groupHeader v-if="group" :key="'groupheader-' + groupid" :group="group" :show-join="true" />
             <CovidClosed v-if="closed" />
             <div v-else>
+              <h2 class="sr-only">
+                List of wanteds and offers
+              </h2>
               <div v-for="message in filteredMessages" :key="'messagelist-' + message.id" class="p-0">
                 <message v-if="(selectedType === 'All' || message.type == selectedType) && (!message.outcomes || message.outcomes.length === 0)" v-bind="message" />
               </div>

--- a/pages/communityevent/_id.vue
+++ b/pages/communityevent/_id.vue
@@ -10,7 +10,7 @@
     <b-row class="m-0">
       <b-col cols="0" md="3" class="d-none d-md-block" />
       <b-col cols="12" md="6" class="p-0">
-        <CommunityEvent v-if="!event.pending" :summary="false" :item="event" class="mt-1" />
+        <CommunityEvent v-if="!event.pending" :summary="false" :item="event" class="mt-1" title-tag="h1" />
         <NoticeMessage v-else>
           Sorry, that event hasn't been approved yet.
         </NoticeMessage>

--- a/pages/communityevents/_id.vue
+++ b/pages/communityevents/_id.vue
@@ -13,6 +13,9 @@
             </b-btn>
           </div>
         </div>
+        <h2 class="sr-only">
+          List of community events
+        </h2>
         <div v-for="event in events" :key="'event-' + event.id" class="mt-2">
           <CommunityEvent v-if="!event.pending" :summary="false" :item="event" />
         </div>

--- a/pages/myposts.vue
+++ b/pages/myposts.vue
@@ -1,5 +1,8 @@
 <template>
   <b-container fluid>
+    <h1 class="sr-only">
+      My posts
+    </h1>
     <b-row class="m-0">
       <b-col cols="0" lg="3" class="d-none d-lg-block p-0 pr-1">
         <SidebarLeft :show-community-events="true" :show-bot-left="true" />
@@ -17,9 +20,9 @@
           no-body
         >
           <template slot="header">
-            <h3 class="d-inline">
+            <h2 class="d-inline header--size3">
               <v-icon name="calendar-alt" scale="2" /> Your Availability
-            </h3>
+            </h2>
           </template>
           <b-card-body>
             <p>
@@ -82,9 +85,9 @@
           no-body
         >
           <template slot="header">
-            <h3 class="d-inline">
+            <h2 class="d-inline header--size3">
               <v-icon name="gift" scale="2" /> Your OFFERs
-            </h3>
+            </h2>
             <span v-if="oldOfferCount > 0">
               <span v-if="showOldOffers" class="float-right">
                 <b-btn variant="white" title="Show old OFFERs" @click="toggleOldOffer">
@@ -135,9 +138,9 @@
           no-body
         >
           <template slot="header">
-            <h3 class="d-inline">
+            <h2 class="d-inline header--size3">
               <v-icon name="search" scale="2" /> Your WANTEDs
-            </h3>
+            </h2>
             <span v-if="oldWantedCount > 0">
               <span v-if="showOldWanteds" class="float-right">
                 <b-btn variant="white" title="Show old WANTEDs" @click="toggleOldWanted">
@@ -182,9 +185,9 @@
           no-body
         >
           <template slot="header">
-            <h3 class="d-inline">
+            <h2 class="d-inline header--size3">
               <v-icon name="search" scale="2" /> Your Searches
-            </h3>
+            </h2>
           </template>
           <b-card-body class="p-1 p-lg-3">
             <b-card-text class="text-center">

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -1,5 +1,8 @@
 <template>
   <div v-if="me && me.settings && me.settings.notifications">
+    <h1 class="sr-only">
+      Settings
+    </h1>
     <client-only>
       <b-row class="m-0">
         <b-col cols="0" xl="3" />
@@ -24,7 +27,10 @@
           </NoticeMessage>
           <b-card border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="globe-europe" /> Your Public Profile
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="globe-europe" />
+                Your Public Profile
+              </h2>
             </template>
             <b-card-body class="p-0 pt-1">
               <p class="text-muted">
@@ -133,7 +139,10 @@
           </b-card>
           <b-card v-if="!simple" border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="globe-europe" /> Arranging Collections
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="globe-europe" />
+                Arranging Collections
+              </h2>
             </template>
             <b-card-body class="p-0 pt-1">
               <p class="text-muted">
@@ -141,7 +150,9 @@
               </p>
               <b-row>
                 <b-col>
-                  <h4>Availability</h4>
+                  <h3 class="header--size4">
+                    Availability
+                  </h3>
                   <p class="mt-2">
                     We can help you arrange a collection time if you tell us when you're available over the next
                     few days.
@@ -153,9 +164,9 @@
               </b-row>
               <b-row>
                 <b-col>
-                  <h4 class="mt-2">
+                  <h3 class="header--size4 mt-2">
                     Address Book
-                  </h4>
+                  </h3>
                   <p class="mt-2">
                     You can save your address and send it to other freeglers, then you don't have to type it each
                     time.
@@ -169,7 +180,10 @@
           </b-card>
           <b-card border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="lock" /> Your Account Settings
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="lock" />
+                Your Account Settings
+              </h2>
             </template>
             <b-card-body class="p-0 pt-1">
               <p class="text-muted">
@@ -244,7 +258,10 @@
           </b-card>
           <b-card border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="envelope" /> Community Mail Settings
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="envelope" />
+                Community Mail Settings
+              </h2>
             </template>
             <div v-if="me.groups && me.groups.length">
               <p>You can pause regular emails for a while, for example if you're on holiday.</p>
@@ -339,7 +356,10 @@
           </b-card>
           <b-card v-if="!simple" border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="bell" /> Chat Notifications
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="bell" />
+                Chat Notifications
+              </h2>
             </template>
             <b-card-body class="p-0 pt-1">
               <p class="text-muted">
@@ -353,7 +373,9 @@
                 Email doesn't always get through, so check your spam folders, and check <em><nuxt-link to="/chats">Chats</nuxt-link></em> on here occasionally.
               </notice-message>
               <hr>
-              <h5>Text Alerts</h5>
+              <h3 class="header--size5 header5__color">
+                Text Alerts
+              </h3>
               <p>We can send you SMS alerts to your phone.</p>
               <b-row>
                 <b-col cols="12" md="8">
@@ -392,7 +414,9 @@
                   </b-alert>
                 </b-col>
               </b-row>
-              <h5>Email Alerts</h5>
+              <h3 class="header--size5 header5__color">
+                Email Alerts
+              </h3>
               <p>
                 Mail me chat messages from other freeglers I'm talking to about OFFERs and WANTEDs.
               </p>
@@ -459,7 +483,9 @@
                 color="#61AE24"
                 @change="changeNewsletter"
               />
-              <h5>Other Alerts</h5>
+              <h3 class="header--size5 header5__color">
+                Other Alerts
+              </h3>
               <p>
                 Apps for your
                 <a href="https://play.google.com/store/apps/details?id=org.ilovefreegle.direct" target="_blank">Android</a> or
@@ -505,11 +531,16 @@
           </b-card>
           <b-card v-if="!simple" border-variant="info" header-bg-variant="info" header-text-variant="white" class="mt-2">
             <template v-slot:header>
-              <v-icon name="cog" /> Other
+              <h2 class="bg-info settings__heading mb-0">
+                <v-icon name="cog" />
+                Other
+              </h2>
             </template>
             <b-card-body class="p-0 pt-1">
               <b-form-group>
-                <h5>What the enter key does</h5>
+                <h3 class="header--size5 header5__color">
+                  What the enter key does
+                </h3>
                 <p>
                   Normally hitting enter/return sends chat messages, rather than add a new line.  If you prefer
                   it to add a new line, then you can change the setting on this device.  This can cause problems
@@ -1025,5 +1056,15 @@ h4 a {
 
 .image__icon {
   color: $color-white;
+}
+
+.settings__heading {
+  font-size: 1rem;
+  font-weight: normal;
+}
+
+.header5__color {
+  /* Need to override the h5 as it has higher specificity */
+  color: #212529 !important;
 }
 </style>

--- a/pages/spread.vue
+++ b/pages/spread.vue
@@ -2,9 +2,9 @@
   <b-row class="m-0 bg-white">
     <b-col cols="0" md="3" />
     <b-col cols="12" md="6" class="mt-2">
-      <h2>
+      <h1 class="header--size2">
         Spread the word
-      </h2>
+      </h1>
       <p>
         Wouldn't the world be better if more people freegled more often? You can help!
       </p>
@@ -17,7 +17,9 @@
       <p>
         You wouldn't be freegling unless someone had told you about it - can you pay it forward?
       </p>
-      <h3>Put up a poster</h3>
+      <h2 class="header--size3">
+        Put up a poster
+      </h2>
       <p>This is an A4 poster with tear-off strips - good for noticeboards in cafes, community venues, or at work.</p>
       <a href="https://freegle.in/A4Poster" target="_blank">
         <b-img-lazy src="~static/posters/A4.png" class="poster border border-dark mb-2" />
@@ -39,7 +41,9 @@
         </nuxt-link>.
       </p>
       <hr>
-      <h3>Invite your friends</h3>
+      <h2 class="header--size3">
+        Invite your friends
+      </h2>
       <div v-if="me && me.invitesleft > 0">
         <p class="bg-info p-2">
           You have <b>{{ me.invitesleft | pluralize('invitation', { includeNumber: true }) }}</b> left.
@@ -93,7 +97,9 @@
         </p>
       </div>
       <hr>
-      <h3>Business Cards</h3>
+      <h2 class="header--size3">
+        Business Cards
+      </h2>
       <p>
         You can get little "business cards" to hand out to people or put on noticeboards.  They're small, so it's
         easy to always have a few with you.
@@ -107,9 +113,9 @@
         </b-btn>
       </a>
       <hr>
-      <h3>
+      <h2 class="header--size3">
         Tell your story
-      </h3>
+      </h2>
       <p>This helps encourage other people to try freegling.</p>
       <b-btn to="/stories" variant="primary" size="lg">
         <v-icon name="book-open" /> Tell your story

--- a/pages/volunteering/_id.vue
+++ b/pages/volunteering/_id.vue
@@ -10,7 +10,7 @@
     <b-row class="m-0">
       <b-col cols="0" md="3" class="d-none d-md-block" />
       <b-col cols="12" md="6" class="p-0">
-        <VolunteerOpportunity v-if="!volunteering.pending" :summary="false" :item="volunteering" class="mt-1" />
+        <VolunteerOpportunity v-if="!volunteering.pending" :summary="false" :item="volunteering" class="mt-1" title-tag="h1" />
         <NoticeMessage v-else>
           Sorry, that volunteer oppportunity hasn't been approved yet.
         </NoticeMessage>
@@ -19,6 +19,7 @@
     </b-row>
   </div>
 </template>
+
 <script>
 import NoticeMessage from '../../components/NoticeMessage'
 import loginOptional from '@/mixins/loginOptional.js'

--- a/pages/volunteerings/_id.vue
+++ b/pages/volunteerings/_id.vue
@@ -13,6 +13,9 @@
             </b-btn>
           </div>
         </div>
+        <h2 class="sr-only">
+          List of volunteer opportunities
+        </h2>
         <div v-for="volunteering in volunteerings" :key="'volunteering-' + volunteering.id" class="mt-2">
           <VolunteerOpportunity v-if="!volunteering.pending" :summary="false" :item="volunteering" />
         </div>


### PR DESCRIPTION
A first go at making some of the pages document structure correct.

The browse, volunteer, volunteerings, event and events pages should now have the correct structure.  I've added some headers that are screen reader only so hidden to sighted users.  The bootstrap card already provides the feature to set the element used for the titles and so I've just used that to pass in the heading level.
