### PR TITLE
Feature/fix mobile reply

### DIFF
--- a/components/Message.vue
+++ b/components/Message.vue
@@ -227,12 +227,7 @@
             Privacy
           </nuxt-link> for details.
         </p>
-        <b-btn v-if="!me" variant="primary" :disabled="disableSend" @click="registerOrSend">
-          Send your reply
-          <v-icon v-if="replying" name="sync" class="fa-spin" />
-          <v-icon v-else name="angle-double-right" />&nbsp;
-        </b-btn>
-        <b-btn v-else variant="primary" :disabled="disableSend" @click="sendReply">
+        <b-btn variant="primary" :disabled="disableSend" class="d-none d-md-block" @click="!me ? registerOrSend : sendReply">
           Send your reply
           <v-icon v-if="replying" name="sync" class="fa-spin" />
           <v-icon v-else name="angle-double-right" />&nbsp;

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -227,7 +227,7 @@
             Privacy
           </nuxt-link> for details.
         </p>
-        <b-btn variant="primary" :disabled="disableSend" class="d-none d-md-block" @click="!me ? registerOrSend : sendReply">
+        <b-btn variant="primary" :disabled="disableSend" class="d-none d-md-block" @click="!me ? registerOrSend() : sendReply()">
           Send your reply
           <v-icon v-if="replying" name="sync" class="fa-spin" />
           <v-icon v-else name="angle-double-right" />&nbsp;


### PR DESCRIPTION
This should fix the problem I mentioned on Slack.  I've added some mobile display classes to the desktop button and I've also just conditionally called the reply method so there isn't code duplication. (registerOrSend and sendReply).

I've given them a test but I wasn't completely sure what they were supposed to do if you weren't logged in so you might want to check that it still does what you would expect.

It might be even nicer to remove that logic from the template completely and put it into the JavaScript to keep the template clean.  But that's another story...