### PR TITLE
Allow the text to wrap so it doesn't push out the screen on mobile

### DIFF
--- a/components/MyMessage.vue
+++ b/components/MyMessage.vue
@@ -23,7 +23,7 @@
                     <v-icon name="exclamation-triangle" scale="2" />
                   </span>
                 </h3>
-                <div v-for="group in message.groups" :key="'message-' + message.id + '-' + group.id" class="small text-muted">
+                <div v-for="group in message.groups" :key="'message-' + message.id + '-' + group.id" class="small text-muted text-wrap">
                   {{ group.arrival | timeago }} on {{ group.namedisplay }} <nuxt-link :to="'/message/' + message.id">
                     <span class="text-muted small">#{{ message.id }}</span>
                   </nuxt-link>

--- a/components/MyMessageReply.vue
+++ b/components/MyMessageReply.vue
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between flex-wrap">
       <div class="d-flex align-content-start mb-1 flex-grow-1">
         <ProfileImage :image="reply.user.profile.turl" class="m-1" is-thumbnail size="sm" />
-        <div class="text-truncate">
+        <div>
           <!-- eslint-disable-next-line -->
           <span  class="align-middle" v-if="unseen > 0"><b>{{ reply.user.displayname }}</b></span>
           <!-- eslint-disable-next-line -->


### PR DESCRIPTION
I haven't given this much of a test yet but thought i'd raise a PR for discussion.

This allow the "2 days ago on FreeglePlayground #1234565" bit to wrap if necessary.  It also allows the "userid last sent" bit of replies to wrap if the username is too long.

See the slack thread for more info...  There are screenshots of the problem attached there.

Are you happy with this wrapping when it doesn't fit or would you rather truncate it?