### PR TITLE
Resolve the row size issues in older Safari

### DIFF
--- a/components/ChatHeader.vue
+++ b/components/ChatHeader.vue
@@ -109,7 +109,7 @@ export default {
   @include media-breakpoint-up(sm) {
     // We want the ratings to use up all the residual space, hence the 1fr.
     grid-template-columns: max-content 1fr max-content 70px;
-    grid-template-rows: auto;
+    grid-template-rows: max-content;
   }
 }
 


### PR DESCRIPTION
I've now left the number of rows the same but just changed the size from auto to max-content.

I've tested this in Chrome, Edge, Firefox and Safari 11 on the desktop and a Galaxy S20/Chrome and an iPhone 11/Safari.