### PR TITLE
Only the notification button should have white text

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -904,7 +904,7 @@ svg.fa-icon {
   max-width: 400px;
 }
 
-::v-deep .dropdown-toggle {
+.notiflist ::v-deep .dropdown-toggle {
   color: $color-white;
 }
 </style>


### PR DESCRIPTION
I've now made the white foreground for dropdown toggles specific to the notification dropdown.  At the time it was only the mobile notifications button that we noticed was the wrong colour so this shouldn't affect anything else.  I've had a quick click around the pages and there isn't anything that stands out.

In the same way that I did a button tidy up so they were all defined in a single place, it might be worth doing the same thing with dropdowns as well.