### PR TITLE
And an associated label to the autocomplete input

### DIFF
--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -633,7 +633,7 @@ export default {
   font-family: sans-serif;
   position: absolute;
   list-style: none;
-  background: $color-gray--lighter;
+  background: $color-white;
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -641,6 +641,9 @@ export default {
   margin-top: 0px;
   z-index: 1000;
   right: 48%;
+  border: 1px solid $color-gray--light;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
 }
 
 ::v-deep .postcodelist.autocomplete ul {
@@ -664,12 +667,14 @@ export default {
   display: block;
   padding: 5px;
   padding-left: 10px;
+  color: $color-gray--dark;
+  font-size: 13px;
 }
 
 .autocomplete ul li a:hover,
 .autocomplete ul li.focus-list a {
-  color: $color-white;
-  background: $color-blue--lighter;
+  color: $color-gray--dark;
+  background: $color-gray--lighter;
 }
 
 .autocomplete ul li a span, /*backwards compat*/
@@ -713,6 +718,9 @@ input[invalid='true'] {
   box-shadow: 0 0 0 0.2rem $color-red;
   border: 1px solid red;
 }
+.autocomplete-wrap {
+  border: 2px solid $color-gray--normal !important;
+}
 .autocomplete-wrap input:focus {
   outline: none;
   box-shadow: none;
@@ -722,10 +730,12 @@ input[invalid='true'] {
   border-color: $color-blue--light;
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  border-color: $color-blue--x-light !important;
 }
 .input-group.autocomplete-wrap {
   border: 1px solid $color-gray-4;
-  border-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 .autocomplete-parent-focus .input-group {
   border: 1px solid $color-gray-4;

--- a/components/PlaceAutocomplete.vue
+++ b/components/PlaceAutocomplete.vue
@@ -1,23 +1,32 @@
 <template>
-  <autocomplete
-    id="placeautocomplete"
-    ref="autocomplete"
-    v-model="wip"
-    restrict
-    :url="source"
-    param="q"
-    :custom-params="{ bbox: '-7.57216793459,49.959999905,1.68153079591,58.6350001085' }"
-    anchor="name"
-    label=""
-    placeholder="Type your location"
-    :classes="{ input: 'form-control form-control-' + size + ' text-center', list: 'locationlist', listentry: 'w-100', listentrylist: 'listentry' }"
-    :min="3"
-    :debounce="200"
-    :process="process"
-    :on-select="select"
-    :size="30"
-    variant="success"
-  />
+  <div>
+    <label for="placeautocomplete" class="smaller font-weight-bold">
+      <span v-if="labeltextSr" class="sr-only">
+        {{ labeltextSr }}
+      </span>
+      {{ labeltext }}
+    </label>
+    <autocomplete
+      id="placeautocomplete"
+      ref="autocomplete"
+      v-model="wip"
+      restrict
+      :url="source"
+      param="q"
+      :custom-params="{ bbox: '-7.57216793459,49.959999905,1.68153079591,58.6350001085' }"
+      anchor="name"
+      label=""
+      placeholder="Type your location"
+      :classes="{ input: 'form-control form-control-' + size + ' text-center', list: 'locationlist', listentry: 'w-100', listentrylist: 'listentry' }"
+      :min="3"
+      :debounce="200"
+      :process="process"
+      :on-select="select"
+      :size="30"
+      variant="success"
+    />
+    <div />
+  </div>
 </template>
 <script>
 import { TooltipPlugin } from 'bootstrap-vue'
@@ -32,6 +41,16 @@ export default {
   },
   props: {
     value: {
+      type: String,
+      required: false,
+      default: null
+    },
+    labeltext: {
+      type: String,
+      required: false,
+      default: null
+    },
+    labeltextSr: {
       type: String,
       required: false,
       default: null

--- a/components/PlaceAutocomplete.vue
+++ b/components/PlaceAutocomplete.vue
@@ -17,7 +17,7 @@
       anchor="name"
       label=""
       placeholder="Type your location"
-      :classes="{ input: 'form-control form-control-' + size + ' text-center', list: 'locationlist', listentry: 'w-100', listentrylist: 'listentry' }"
+      :classes="{ input: 'form-control form-control-' + size + ' text-center', list: 'locationlist', listentry: 'w-100 listentry', listentrylist: 'listentrylist' }"
       :min="3"
       :debounce="200"
       :process="process"
@@ -140,9 +140,15 @@ export default {
   }
 }
 </script>
+
 <style scoped lang="scss">
-::v-deep .listentry {
+@import 'color-vars';
+
+::v-deep .listentrylist {
   width: 100%;
   right: 0 !important;
+  border-color: $color-blue--light;
+  outline: 0;
+  box-shadow: 0 1px 0 0.2rem rgba(0, 123, 255, 0.25);
 }
 </style>

--- a/components/Postcode.vue
+++ b/components/Postcode.vue
@@ -247,10 +247,16 @@ export default {
   }
 }
 </script>
+
 <style scoped lang="scss">
+@import 'color-vars';
+
 ::v-deep .listentry {
   width: 100%;
   right: 0 !important;
   text-align: center;
+  border-color: $color-blue--light;
+  outline: 0;
+  box-shadow: 0 1px 0 0.2rem rgba(0, 123, 255, 0.25);
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -359,8 +359,4 @@ export default {
   padding-top: 9px;
   padding-bottom: 9px;
 }
-
-::v-deep .autocomplete-wrap {
-  border: 3px solid $color-green--darker !important;
-}
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,14 +40,8 @@
       <h2 class="medium font-weight-bold black">
         Just looking?
       </h2>
-      <label class="smaller font-weight-bold">
-        <span class="sr-only">
-          Enter your location and
-        </span>
-        See what's being freegled near you.
-      </label>
       <div class="d-flex centresmall flex-wrap">
-        <PlaceAutocomplete class="mb-2" @selected="explorePlace($event)" />
+        <PlaceAutocomplete class="mb-2" labeltext="See what's being freegled near you." labeltext-sr="Enter your location and" @selected="explorePlace($event)" />
       </div>
     </div>
     <div class="mobile">


### PR DESCRIPTION
All input fields should have an associated label.  This input had a label but it wasn't connected to the input field.

With the label and input in different components it was awkward to associate them together.  

One option would be to pass the input id into the component and use it in both the parent and child but that felt messy.  It felt right to have the label and the input together.

The awkwardness here then comes from the normal label and the screenreader label.  The two options here are pass in a couple of props or to use a slot.  A slot felt a bit overkill.  The only problem with the solution I've gone for is it's not that easy to validate that someone will pass in at least one of the two.  I suppose another way to look at it is that there is no validation on a regular input field so we are not making anything worse than the norm.

Another issue is that autocomplete isn't accessible but that's another story...