### PR TITLE
Feature/add word highlight to search

### DIFF
--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -48,7 +48,13 @@
             <!-- eslint-disable-next-line -->
             <div v-if="onShouldRenderChild" v-html="onShouldRenderChild(data)" />
             <div v-if="!onShouldRenderChild">
-              <b class="autocomplete-anchor-text">{{ deepValue(data, anchor) }}</b>
+              <Highlighter
+                :text-to-highlight="deepValue(data, anchor)"
+                :search-words="[type]"
+                highlight-class-name="highlight"
+                auto-escape
+              />
+              <!--<span class="autocomplete-anchor-text">{{ deepValue(data, anchor) }}</span>-->
               <span class="autocomplete-anchor-label">{{ deepValue(data, label) }}</span>
             </div>
           </a>
@@ -74,8 +80,12 @@
 /* eslint-disable */
 
 import cloneDeep from 'lodash.clonedeep'
+const Highlighter = () => import('vue-highlight-words')
 
 export default {
+  components: {
+    Highlighter
+  },
   props: {
     id: String,
     name: String,
@@ -677,7 +687,6 @@ export default {
   background: $color-gray--lighter;
 }
 
-.autocomplete ul li a span, /*backwards compat*/
 .autocomplete ul li a .autocomplete-anchor-label {
   display: block;
   margin-top: 3px;
@@ -761,5 +770,10 @@ input[invalid='true'] {
 }
 input[invalid='true'] {
   box-shadow: none;
+}
+
+.highlight {
+  font-weight: bold;
+  background-color: initial;
 }
 </style>

--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -53,6 +53,7 @@
                 :search-words="[type]"
                 highlight-class-name="highlight"
                 auto-escape
+                class="autocomplete-anchor-text"
               />
               <!--<span class="autocomplete-anchor-text">{{ deepValue(data, anchor) }}</span>-->
               <span class="autocomplete-anchor-label">{{ deepValue(data, label) }}</span>
@@ -671,6 +672,19 @@ export default {
 /*left: 46%;*/
 /*top: -20px*/
 /*}*/
+
+.autocomplete-anchor-text {
+  color: $color-gray--dark !important;
+}
+
+.autocomplete-anchor-text span {
+  color: $color-gray--dark !important;
+}
+
+.autocomplete-anchor-text:hover {
+  color: $color-gray--dark;
+  background: $color-gray--lighter;
+}
 
 .autocomplete ul li a {
   text-decoration: none;

--- a/components/Autocomplete.vue
+++ b/components/Autocomplete.vue
@@ -55,7 +55,6 @@
                 auto-escape
                 class="autocomplete-anchor-text"
               />
-              <!--<span class="autocomplete-anchor-text">{{ deepValue(data, anchor) }}</span>-->
               <span class="autocomplete-anchor-label">{{ deepValue(data, label) }}</span>
             </div>
           </a>

--- a/components/PlaceAutocomplete.vue
+++ b/components/PlaceAutocomplete.vue
@@ -151,4 +151,9 @@ export default {
   outline: 0;
   box-shadow: 0 1px 0 0.2rem rgba(0, 123, 255, 0.25);
 }
+
+::v-deep .listentry mark {
+  padding-left: 0;
+  padding-right: 0;
+}
 </style>


### PR DESCRIPTION
Take a look and see what you think of the search highlighting.  

The autocomplete code is a bit of a mess - I'm guessing because it was ported from another repo.  Do we ever use the "(data, label)" bit as opposed to the "(data,anchor)" - for example in the ul dropdown list part?  There is a lot of styling attached to that and also quite a bit of styling that says "backwards compatibility".  I'm a bit scared to just remove it!