### PR TITLE
Sort out the header document outline for jobs

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -161,6 +161,10 @@ h1, h2, h3, h4 {
   font-size: 1.25rem;
 }
 
+.header--size6 {
+  font-size: 1rem;
+}
+
 div[variant="success"] .card-header {
   color: $colour-success-fg;
   background-color: $color-green--light;

--- a/components/Job.vue
+++ b/components/Job.vue
@@ -1,10 +1,10 @@
 <template>
   <div @click="clicked">
     <div v-if="summary" class="ml-2 mr-2">
-      <h6>
+      <h3 class="header--size6">
         <!-- eslint-disable-next-line -->
         <span v-html="joblinksumm" />
-      </h6>
+      </h3>
       <p class="text-truncate mt-2">
         {{ job.snippet }}
       </p>

--- a/components/JobsSidebar.vue
+++ b/components/JobsSidebar.vue
@@ -14,9 +14,9 @@
           <v-icon name="search" /> View more
         </b-btn>
         <nuxt-link to="/communityevents">
-          <h4 class="pl-1 pt-1">
+          <h2 class="header--size4 pl-1 pt-1">
             <v-icon name="briefcase" scale="2" /> Jobs
-          </h4>
+          </h2>
         </nuxt-link>
         <p class="text-center small">
           Jobs near you.  Freegle gets a small amount if you click.

--- a/components/JobsTopBar.vue
+++ b/components/JobsTopBar.vue
@@ -11,6 +11,9 @@
       <donation-button />
     </NoticeMessage>
     <div v-else>
+      <h2 class="sr-only">
+        Jobs
+      </h2>
       <div class="mb-1 text-center small text-muted">
         Jobs near you.  Freegle gets a small amount if you click, which helps keep us going.  <nuxt-link to="/jobs">
           See more jobs


### PR DESCRIPTION
I've kept the same sizes but added the correct header levels when jobs are on the top and on the side.