### PR TITLE
Feature/accessibility updates to selects

### DIFF
--- a/components/AdaptiveMap.vue
+++ b/components/AdaptiveMap.vue
@@ -85,9 +85,11 @@
           Search Filters
         </h2>
         <div v-if="filters" variant="info" class="p-2 border border-info bg-white filters">
-          <GroupSelect v-model="selectedGroup" all :all-my="false" />
+          <label for="communitiesList" class="sr-only">Communities to view</label>
+          <GroupSelect v-model="selectedGroup" selectid="communitiesList" all :all-my="false" />
           <div />
-          <b-form-select v-model="selectedType" :options="typeOptions" class="shrink" />
+          <label for="typeOptions" class="sr-only">Type of posts to view</label>
+          <b-form-select id="typeOptions" v-model="selectedType" :options="typeOptions" class="shrink" />
           <div />
           <b-input-group class="shrink mt-1 mt-sm-0 search">
             <b-input

--- a/components/AdaptiveMap.vue
+++ b/components/AdaptiveMap.vue
@@ -85,8 +85,13 @@
           Search Filters
         </h2>
         <div v-if="filters" variant="info" class="p-2 border border-info bg-white filters">
-          <label for="communitiesList" class="sr-only">Communities to view</label>
-          <GroupSelect v-model="selectedGroup" selectid="communitiesList" all :all-my="false" />
+          <GroupSelect
+            v-model="selectedGroup"
+            label="Communities to view"
+            label-sr-only
+            all
+            :all-my="false"
+          />
           <div />
           <label for="typeOptions" class="sr-only">Type of posts to view</label>
           <b-form-select id="typeOptions" v-model="selectedType" :options="typeOptions" class="shrink" />

--- a/components/GroupSelect.vue
+++ b/components/GroupSelect.vue
@@ -1,7 +1,8 @@
 <template>
   <client-only>
     <div>
-      <b-form-select :id="selectid" v-model="selectedGroup" size=":size" :options="groupOptions" />
+      <label v-if="label" for="communitieslist" :class="labelSrOnly ? 'sr-only' : ''">{{ label }}</label>
+      <b-form-select id="communitieslist" v-model="selectedGroup" size=":size" :options="groupOptions" />
     </div>
   </client-only>
 </template>
@@ -25,10 +26,15 @@ export default {
      *
      * (0 is not a valid group number)
      */
-    selectid: {
+    label: {
       type: String,
       required: false,
       default: ''
+    },
+    labelSrOnly: {
+      type: Boolean,
+      required: false,
+      default: false
     },
     value: {
       type: Number,

--- a/components/GroupSelect.vue
+++ b/components/GroupSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <client-only>
     <div>
-      <b-form-select v-model="selectedGroup" size=":size" :options="groupOptions" />
+      <b-form-select :id="selectid" v-model="selectedGroup" size=":size" :options="groupOptions" />
     </div>
   </client-only>
 </template>
@@ -25,6 +25,11 @@ export default {
      *
      * (0 is not a valid group number)
      */
+    selectid: {
+      type: String,
+      required: false,
+      default: ''
+    },
     value: {
       type: Number,
       default: null


### PR DESCRIPTION
Add sr-only labels to the two select fields.  I've changed the GroupSelect component to have a label field but it's not mandatory (for now).  It felt right to have this in the same component alongside the select field itself.  i.e. the select field in GroupSelect should always have a label so it should be contained together.