### PR TITLE
Feature/chat html tidy

### DIFF
--- a/components/ChatFooter.vue
+++ b/components/ChatFooter.vue
@@ -51,7 +51,7 @@
           placeholder="Type here..."
           rows="3"
           max-rows="8"
-          :autocapitalize="enterNewLine ? 'none' : false"
+          :autocapitalize="enterNewLine ? false : 'none'"
           @focus="markRead"
           @[keydownEventIfNotEnterForNewLine].enter.prevent=""
           @[keydownEventIfNotEnterForNewLine].enter.shift.exact.prevent="newline"

--- a/components/ChatFooter.vue
+++ b/components/ChatFooter.vue
@@ -224,7 +224,7 @@ export default {
     keydownEventIfNotEnterForNewLine() {
       return this.enterNewLine ? null : 'keydown'
     },
-    keyupeventIfNotEnterForNewLine() {
+    keyupEventIfNotEnterForNewLine() {
       return this.enterNewLine ? null : 'keyup'
     }
   }

--- a/components/ChatFooter.vue
+++ b/components/ChatFooter.vue
@@ -41,29 +41,24 @@
         </notice-message>
         <ModComments v-if="mod && chat && chat.chattype === 'User2Mod' && otheruser" :user="otheruser" class="mt-1" />
       </div>
-      <b-form-textarea
-        v-if="enterNewLine && !spammer"
-        ref="chatarea"
-        v-model="sendmessage"
-        placeholder="Type here..."
-        rows="3"
-        max-rows="8"
-        @focus="markRead"
-      />
-      <b-form-textarea
-        v-else-if="!spammer"
-        ref="chatarea"
-        v-model="sendmessage"
-        placeholder="Type here..."
-        rows="3"
-        max-rows="8"
-        autocapitalize="none"
-        @keydown.enter.exact.prevent
-        @keyup.enter.exact="send"
-        @keydown.enter.shift.exact.prevent="newline"
-        @keydown.alt.shift.exact.prevent="newline"
-        @focus="markRead"
-      />
+      <div v-if="!spammer">
+        <label for="chatmessage" class="sr-only">Chat message</label>
+        <!-- autocapitalize is set to none because of this - https://github.com/angular/angular/issues/32963 -->
+        <b-form-textarea
+          id="chatmessage"
+          ref="chatarea"
+          v-model="sendmessage"
+          placeholder="Type here..."
+          rows="3"
+          max-rows="8"
+          :autocapitalize="enterNewLine ? 'none' : false"
+          @focus="markRead"
+          @[keydownEventIfNotEnterForNewLine].enter.prevent=""
+          @[keydownEventIfNotEnterForNewLine].enter.shift.exact.prevent="newline"
+          @[keydownEventIfNotEnterForNewLine].alt.shift.exact.prevent="newline"
+          @[keyupEventIfNotEnterForNewLine].enter.exact="send"
+        />
+      </div>
     </div>
     <div v-if="!spammer" class="bg-white pt-1 pb-1">
       <div class="d-none d-lg-block">
@@ -224,7 +219,15 @@ export default {
     AddressModal,
     ChatRSVPModal
   },
-  mixins: [waitForRef, chat, chatCollate]
+  mixins: [waitForRef, chat, chatCollate],
+  computed: {
+    keydownEventIfNotEnterForNewLine() {
+      return this.enterNewLine ? null : 'keydown'
+    },
+    keyupeventIfNotEnterForNewLine() {
+      return this.enterNewLine ? null : 'keyup'
+    }
+  }
 }
 </script>
 <style scoped lang="scss">


### PR DESCRIPTION
OK this is the refactor of the chat message box to remove the duplicated HTML and to make it accessible by adding a label.  Do you want to take a look and see what you think?  I've so far only tested it on Chrome on W10.  I'll give it a test tomorrow on other devices.

I currently can't test the alt-shift combination as on Windows 10 it appears to be the key combination to change language.  There wasn't an obvious way of switching this off but I'll investigate further.