### PR TITLE
Refactor the notification options into a separate component.

### DIFF
--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -1,82 +1,43 @@
 <template>
-  <div>
-    <!-- Notification menu option for large screens -->
-    <b-nav-item-dropdown
-      v-if="!simple"
-      class="white text-center notification-list d-none d-xl-block"
-      toggle-class="notification-list__dropdown-toggle"
-      menu-class="notification-list__dropdown-menu"
-      lazy
-      right
-      @shown="loadLatestNotifications"
-    >
-      <template slot="button-content">
-        <div class="position-relative text-center small">
-          <v-icon name="bell" scale="2" class="notification-list__icon" />
-          <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
-            {{ unreadNotificationCount }}
-          </b-badge><br>
-          <span class="nav-item__text">Notifications</span>
-        </div>
-      </template>
-      <b-dropdown-item class="text-right" link-class="notification-list__item">
-        <b-btn variant="white" size="sm" @click="markAllRead">
-          Mark all read
-        </b-btn>
-      </b-dropdown-item>
-      <b-dropdown-divider />
-      <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad" link-class="notification-list__item">
-        <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
-      </b-dropdown-item>
-      <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
-        <span slot="no-results" />
-        <span slot="no-more" />
-        <span slot="spinner">
-          <b-img-lazy src="~/static/loader.gif" alt="Loading" />
-        </span>
-      </infinite-loading>
-    </b-nav-item-dropdown>
-
-    <!-- Notification menu option for small screens -->
-    <b-dropdown
-      v-if="loggedIn"
-      class="white text-center notification-list mr-2 d-block d-xl-none"
-      variant="transparent"
-      toggle-class="notification-list__dropdown-toggle"
-      menu-class="notification-list__dropdown-menu"
-      lazy
-      right
-      @shown="loadLatestNotifications"
-    >
-      <template slot="button-content">
-        <div class="position-relative">
-          <v-icon name="bell" scale="2" class="notification-list__icon" />
-          <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
-            {{ unreadNotificationCount }}
-          </b-badge>
-        </div>
-      </template>
-      <b-dropdown-item class="text-right">
-        <b-btn variant="white" size="sm" @click="markAllRead">
-          Mark all read
-        </b-btn>
-      </b-dropdown-item>
-      <b-dropdown-divider />
-      <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad">
-        <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
-      </b-dropdown-item>
-      <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
-        <span slot="no-results" />
-        <span slot="no-more" />
-        <span slot="spinner">
-          <b-img-lazy src="~/static/loader.gif" alt="Loading" />
-        </span>
-      </infinite-loading>
-    </b-dropdown>
+  <component
+    :is="whatami"
+    v-if="!simple"
+    class="white text-center notification-list"
+    toggle-class="notification-list__dropdown-toggle"
+    menu-class="notification-list__dropdown-menu"
+    lazy
+    right
+    @shown="loadLatestNotifications"
+  >
+    <template slot="button-content">
+      <div class="position-relative text-center small">
+        <v-icon name="bell" scale="2" class="notification-list__icon" />
+        <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
+          {{ unreadNotificationCount }}
+        </b-badge><br>
+        <span v-if="!smallScreen" class="nav-item__text">Notifications</span>
+      </div>
+    </template>
+    <b-dropdown-item class="text-right" link-class="notification-list__item">
+      <b-btn variant="white" size="sm" @click="markAllRead">
+        Mark all read
+      </b-btn>
+    </b-dropdown-item>
+    <b-dropdown-divider />
+    <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad" link-class="notification-list__item">
+      <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
+    </b-dropdown-item>
+    <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
+      <span slot="no-results" />
+      <span slot="no-more" />
+      <span slot="spinner">
+        <b-img-lazy src="~/static/loader.gif" alt="Loading" />
+      </span>
+    </infinite-loading>
     <client-only>
       <AboutMeModal ref="aboutMeModal" />
     </client-only>
-  </div>
+  </component>
 </template>
 
 <script>
@@ -94,9 +55,16 @@ export default {
     distance: {
       type: Number,
       required: true
+    },
+    smallScreen: {
+      type: Boolean,
+      required: false
     }
   },
   computed: {
+    whatami() {
+      return this.smallScreen ? 'b-nav-item-dropdown' : 'b-dropdown'
+    },
     notifications() {
       return this.$store.getters[
         'notifications/getCurrentListInDescendingDateOrder'

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="whatami"
+    :is="notificationType"
     v-if="!simple"
     class="white text-center notification-list"
     toggle-class="notification-list__dropdown-toggle"
@@ -62,8 +62,8 @@ export default {
     }
   },
   computed: {
-    whatami() {
-      return this.smallScreen ? 'b-nav-item-dropdown' : 'b-dropdown'
+    notificationType() {
+      return this.smallScreen ? 'b-dropdown' : 'b-nav-item-dropdown'
     },
     notifications() {
       return this.$store.getters[

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -1,0 +1,210 @@
+<template>
+  <div>
+    <!-- Notification menu option  for large screens -->
+    <b-nav-item-dropdown
+      v-if="!simple"
+      class="white text-center notification-list d-none d-xl-block"
+      toggle-class="notification-list__dropdown-toggle"
+      menu-class="notification-list__dropdown-menu"
+      lazy
+      right
+      @shown="loadLatestNotifications"
+    >
+      <template slot="button-content">
+        <div class="position-relative text-center small">
+          <v-icon name="bell" scale="2" class="notification-list__icon" />
+          <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
+            {{ unreadNotificationCount }}
+          </b-badge><br>
+          <span class="nav-item__text">Notifications</span>
+        </div>
+      </template>
+      <b-dropdown-item class="text-right" link-class="notification-list__item">
+        <b-btn variant="white" size="sm" @click="markAllRead">
+          Mark all read
+        </b-btn>
+      </b-dropdown-item>
+      <b-dropdown-divider />
+      <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad" link-class="notification-list__item">
+        <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
+      </b-dropdown-item>
+      <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
+        <span slot="no-results" />
+        <span slot="no-more" />
+        <span slot="spinner">
+          <b-img-lazy src="~/static/loader.gif" alt="Loading" />
+        </span>
+      </infinite-loading>
+    </b-nav-item-dropdown>
+
+    <!-- Notification menu option for small screens -->
+    <b-dropdown
+      v-if="loggedIn"
+      class="white text-center notification-list mr-2 d-block d-xl-none"
+      variant="transparent"
+      toggle-class="notification-list__dropdown-toggle"
+      menu-class="notification-list__dropdown-menu"
+      lazy
+      right
+      @shown="loadLatestNotifications"
+    >
+      <template slot="button-content">
+        <div class="position-relative">
+          <v-icon name="bell" scale="2" class="notification-list__icon" />
+          <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
+            {{ unreadNotificationCount }}
+          </b-badge>
+        </div>
+      </template>
+      <b-dropdown-item class="text-right">
+        <b-btn variant="white" size="sm" @click="markAllRead">
+          Mark all read
+        </b-btn>
+      </b-dropdown-item>
+      <b-dropdown-divider />
+      <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad">
+        <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
+      </b-dropdown-item>
+      <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
+        <span slot="no-results" />
+        <span slot="no-more" />
+        <span slot="spinner">
+          <b-img-lazy src="~/static/loader.gif" alt="Loading" />
+        </span>
+      </infinite-loading>
+    </b-dropdown>
+  </div>
+</template>
+
+<script>
+const Notification = () => import('~/components/Notification')
+const InfiniteLoading = () => import('vue-infinite-loading')
+
+export default {
+  components: {
+    InfiniteLoading,
+    Notification
+  },
+  props: {
+    distance: {
+      type: Number,
+      required: true
+    },
+    parentRefs: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    notifications() {
+      return this.$store.getters[
+        'notifications/getCurrentListInDescendingDateOrder'
+      ]
+    },
+    unreadNotificationCount() {
+      return this.$store.getters['notifications/getUnreadCount']
+    }
+  },
+  mounted() {
+    const me = this.$store.getters['auth/user']
+
+    if (me && me.id) {
+      // Get notifications and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
+      this.$store.dispatch('notifications/updateNotifications')
+    }
+  },
+  methods: {
+    loadLatestNotifications() {
+      // We want to make sure we have the most up to date notifications.
+      this.complete = false
+      this.$store.dispatch('notifications/clear')
+      this.$store.dispatch('notifications/fetchNextListChunk')
+    },
+    loadMoreNotifications: function($state) {
+      const currentCount = this.notifications.length
+
+      if (this.complete) {
+        $state.complete()
+      } else {
+        this.busy = true
+        this.$store
+          .dispatch('notifications/fetchNextListChunk')
+          .then(() => {
+            try {
+              const notifications = this.$store.getters[
+                'notifications/getCurrentList'
+              ]
+
+              if (currentCount === notifications.length) {
+                this.complete = true
+                $state.complete()
+              } else {
+                $state.loaded()
+              }
+              this.busy = false
+            } catch (e) {
+              console.error(e)
+              console.log('Error')
+            }
+          })
+          .catch(e => {
+            console.error(e)
+            this.busy = false
+            $state.complete()
+          })
+      }
+    },
+    async markAllRead() {
+      await this.$store.dispatch('notifications/allSeen')
+      await this.$store.dispatch('notifications/updateUnreadNotificationCount')
+      await this.$store.dispatch('notifications/fetchNextListChunk')
+    },
+    showAboutMe() {
+      this.parentRefs.aboutMeModal.show()
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/_breakpoints';
+
+.notification-badge {
+  position: absolute;
+  top: 0px;
+  left: 18px;
+
+  @include media-breakpoint-up(xl) {
+    left: 40px;
+  }
+}
+
+.notification-list {
+  max-width: 100%;
+}
+
+.notification-list__icon {
+  height: 32px;
+  margin-bottom: 0;
+}
+
+/* These classes style the bootstrap b-nav-item-dropdown component */
+::v-deep .notification-list__dropdown-toggle {
+  color: $color-white !important;
+}
+
+::v-deep .notification-list__dropdown-menu {
+  height: 500px;
+  overflow-y: auto;
+}
+
+.notification-list ::v-deep .dropdown-item {
+  width: 300px;
+  max-width: 100%;
+  padding-left: 5px;
+  overflow-wrap: break-word;
+}
+</style>

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -73,17 +73,22 @@
         </span>
       </infinite-loading>
     </b-dropdown>
+    <client-only>
+      <AboutMeModal ref="aboutMeModal" />
+    </client-only>
   </div>
 </template>
 
 <script>
 const Notification = () => import('~/components/Notification')
 const InfiniteLoading = () => import('vue-infinite-loading')
+const AboutMeModal = () => import('~/components/AboutMeModal')
 
 export default {
   components: {
     InfiniteLoading,
-    Notification
+    Notification,
+    AboutMeModal
   },
   props: {
     distance: {
@@ -160,7 +165,7 @@ export default {
       await this.$store.dispatch('notifications/fetchNextListChunk')
     },
     showAboutMe() {
-      this.parentRefs.aboutMeModal.show()
+      this.$refs.aboutMeModal.show()
     }
   }
 }

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -94,10 +94,6 @@ export default {
     distance: {
       type: Number,
       required: true
-    },
-    parentRefs: {
-      type: Object,
-      required: true
     }
   },
   computed: {
@@ -108,6 +104,11 @@ export default {
     },
     unreadNotificationCount() {
       return this.$store.getters['notifications/getUnreadCount']
+    }
+  },
+  watch: {
+    unreadNotificationCount: function() {
+      this.$emit('unread-notification-count', this.unreadNotificationCount)
     }
   },
   mounted() {

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <!-- Notification menu option  for large screens -->
+    <!-- Notification menu option for large screens -->
     <b-nav-item-dropdown
       v-if="!simple"
       class="white text-center notification-list d-none d-xl-block"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <span id="breakpoint-test-element" class="d-none d-xl-inline" />
     <!-- Navbar for large screens-->
     <b-navbar id="navbar_large" toggleable="xl" type="dark" class="ourBack d-none d-xl-flex pl-1" fixed="top">
       <b-navbar-brand to="/" class="p-0">
@@ -51,7 +52,7 @@
             </div>
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
-            <NotificationOptions :distance="distance" @unread-notification-count="unreadNotificationCount=$event" />
+            <NotificationOptions :distance="distance" :small-screen="sm" @unread-notification-count="unreadNotificationCount=$event" />
             <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @click="toChats">
               <div class="notifwrapper">
                 <v-icon name="comments" scale="2" /><br>
@@ -109,7 +110,7 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <NotificationOptions :distance="distance" @unread-notification-count="unreadNotificationCount=$event" />
+          <NotificationOptions :distance="distance" :small-screen="sm" @unread-notification-count="unreadNotificationCount=$event" />
           <a v-if="loggedIn" id="menu-option-chat-sm" href="#" class="text-white mr-3 position-relative" @click="toChats">
             <v-icon name="comments" scale="2" /><br>
             <b-badge v-if="chatCount" variant="danger" class="chatbadge">
@@ -257,6 +258,24 @@ export default {
     },
     spreadCount() {
       return this.me && this.me.invitesleft ? this.me.invitesleft : 0
+    },
+    sm() {
+      // Detect breakpoint by checking computing style of an element which uses the bootstrap classes
+      let ret = false
+      console.log('XXXX')
+
+      if (process.client) {
+        const el = document.getElementById('breakpoint-test-element')
+        if (el) {
+          const display = getComputedStyle(el, null).display
+          console.log(display)
+          if (display === 'none') {
+            ret = true
+          }
+        }
+      }
+
+      return ret
     }
   },
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -190,7 +190,6 @@
     <client-only>
       <ChatPopups v-if="loggedIn" class="d-none d-sm-block" />
       <LoginModal ref="loginModal" />
-      <AboutMeModal ref="aboutMeModal" />
     </client-only>
     <div class="navbar-toggle" style="display: none" />
     <div id="serverloader" class="bg-white">
@@ -210,7 +209,6 @@ import LocalStorageMonitor from '~/components/LocalStorageMonitor'
 import BouncingEmail from '~/components/BouncingEmail'
 import NotificationOptions from '~/components/NotificationOptions'
 
-const AboutMeModal = () => import('~/components/AboutMeModal')
 const ChatPopups = () => import('~/components/ChatPopups')
 const NchanSubscriber = require('nchan')
 const ExternalLink = () => import('~/components/ExternalLink')
@@ -219,7 +217,6 @@ export default {
   components: {
     SimpleView,
     ChatPopups,
-    AboutMeModal,
     LoginModal,
     LocalStorageMonitor,
     BouncingEmail,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,7 +51,7 @@
             </div>
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
-            <NotificationOptions :distance="distance" :parent-refs="$refs" />
+            <NotificationOptions :distance="distance" @unread-notification-count="unreadNotificationCount=$event" />
             <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @click="toChats">
               <div class="notifwrapper">
                 <v-icon name="comments" scale="2" /><br>
@@ -109,7 +109,7 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <NotificationOptions :distance="distance" :parent-refs="$refs" />
+          <NotificationOptions :distance="distance" @unread-notification-count="unreadNotificationCount=$event" />
           <a v-if="loggedIn" id="menu-option-chat-sm" href="#" class="text-white mr-3 position-relative" @click="toChats">
             <v-icon name="comments" scale="2" /><br>
             <b-badge v-if="chatCount" variant="danger" class="chatbadge">
@@ -231,7 +231,8 @@ export default {
       chatPoll: null,
       nchan: null,
       logo: require(`@/static/icon.png`),
-      timeTimer: null
+      timeTimer: null,
+      unreadNotificationCount: 0
     }
   },
 
@@ -250,9 +251,6 @@ export default {
   },
 
   computed: {
-    unreadNotificationCount() {
-      return this.$store.getters['notifications/getUnreadCount']
-    },
     chatCount() {
       // Don't show so many that the layout breaks.
       return Math.min(99, this.$store.getters['chats/unseenCount'])

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <span id="breakpoint-test-element" class="d-none d-xl-inline" />
     <!-- Navbar for large screens-->
     <b-navbar id="navbar_large" toggleable="xl" type="dark" class="ourBack d-none d-xl-flex pl-1" fixed="top">
       <b-navbar-brand to="/" class="p-0">
@@ -52,7 +51,7 @@
             </div>
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
-            <NotificationOptions :distance="distance" :small-screen="sm" @unread-notification-count="unreadNotificationCount=$event" />
+            <NotificationOptions :distance="distance" :small-screen="false" @unread-notification-count="unreadNotificationCount=$event" />
             <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @click="toChats">
               <div class="notifwrapper">
                 <v-icon name="comments" scale="2" /><br>
@@ -110,7 +109,7 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <NotificationOptions :distance="distance" :small-screen="sm" @unread-notification-count="unreadNotificationCount=$event" />
+          <NotificationOptions :distance="distance" :small-screen="true" @unread-notification-count="unreadNotificationCount=$event" />
           <a v-if="loggedIn" id="menu-option-chat-sm" href="#" class="text-white mr-3 position-relative" @click="toChats">
             <v-icon name="comments" scale="2" /><br>
             <b-badge v-if="chatCount" variant="danger" class="chatbadge">
@@ -258,24 +257,6 @@ export default {
     },
     spreadCount() {
       return this.me && this.me.invitesleft ? this.me.invitesleft : 0
-    },
-    sm() {
-      // Detect breakpoint by checking computing style of an element which uses the bootstrap classes
-      let ret = false
-      console.log('XXXX')
-
-      if (process.client) {
-        const el = document.getElementById('breakpoint-test-element')
-        if (el) {
-          const display = getComputedStyle(el, null).display
-          console.log(display)
-          if (display === 'none') {
-            ret = true
-          }
-        }
-      }
-
-      return ret
     }
   },
 


### PR DESCRIPTION
This is the next phase of tidying up default.vue

I've currently set it to draft as I haven't fully tested it yet but thought I'd get your opinion on it.

At the moment I've just taken out anything to do with notifications and put it in the component.  It's still got two separate HTML sections; one for large and one for small screens.

One part I'm unsure about is I've left the unreadNotificationCount property in default.vue.  Because it needs to be real-time, it doesn't really work living in the component and raising an event to the parent as there is nothing currently to trigger it.  I can't think of another way to handle it which isn't horrible.  Thinking about it now I'm not actually sure if the head method is reactive anyway.  I'll check on that...