### PR TITLE
Add some space between the grid columns

### DIFF
--- a/components/PostMessage.vue
+++ b/components/PostMessage.vue
@@ -333,6 +333,7 @@ export default {
   display: grid;
   grid-template-columns: 1fr 50px 1fr;
   grid-template-rows: auto auto;
+  grid-column-gap: 5px;
 
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 3fr auto;


### PR DESCRIPTION
Add some breathing space to the gird items. 

grid-column-gap and grid-gap have actually been deprecated but we still need to support the older browsers.