### PR TITLE
Refactor the notification options into a component

### DIFF
--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -31,6 +31,7 @@ export default {
   },
   computed: {
     chatType() {
+      // A different component needs to be created depending on the context in which it's used
       return this.smallScreen ? 'a' : 'b-nav-item'
     },
     chatCount() {

--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -41,7 +41,7 @@ export default {
   },
   watch: {
     chatCount: function() {
-      this.$emit('chat-count', this.chatCount)
+      this.$emit('update:chatCount', this.chatCount)
     }
   },
   methods: {

--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -8,8 +8,10 @@
     @click="toChats"
   >
     <div class="position-relative">
-      <v-icon name="comments" scale="2" /><br>
-      <span v-if="!smallScreen" class="nav-item__text">Chats</span>
+      <v-icon name="comments" scale="2" />
+      <div v-if="!smallScreen" class="nav-item__text">
+        Chats
+      </div>
       <b-badge v-if="chatCount" variant="danger" class="chatbadge">
         {{ chatCount }}
       </b-badge>
@@ -65,5 +67,10 @@ export default {
   position: absolute;
   top: 0px;
   left: 25px;
+}
+
+svg.fa-icon {
+  height: 32px;
+  margin: 0;
 }
 </style>

--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -1,0 +1,69 @@
+<template>
+  <component
+    :is="chatType"
+    :id="smallScreen ? 'menu-option-chat-sm' : 'menu-option-chat'"
+    :class="smallScreen ? 'text-white mr-3 position-relative' : 'text-center small p-0'"
+    href="#"
+    aria-label="chats"
+    @click="toChats"
+  >
+    <div class="position-relative">
+      <v-icon name="comments" scale="2" /><br>
+      <span v-if="!smallScreen" class="nav-item__text">Chats</span>
+      <b-badge v-if="chatCount" variant="danger" class="chatbadge">
+        {{ chatCount }}
+      </b-badge>
+    </div>
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'ChatMenu',
+  props: {
+    smallScreen: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  computed: {
+    chatType() {
+      return this.smallScreen ? 'a' : 'b-nav-item'
+    },
+    chatCount() {
+      // Don't show so many that the layout breaks.
+      return Math.min(99, this.$store.getters['chats/unseenCount'])
+    }
+  },
+  watch: {
+    chatCount: function() {
+      this.$emit('chat-count', this.chatCount)
+    }
+  },
+  methods: {
+    toChats(e) {
+      if (e) {
+        e.preventDefault()
+        e.stopPropagation()
+        e.stopImmediatePropagation()
+      }
+
+      // Ensure we have no chat selected.  On mobile this will force us to show the chat list.
+      this.$store.dispatch('chats/currentChat', {
+        chatid: null
+      })
+
+      this.$router.push('/chats')
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.chatbadge {
+  position: absolute;
+  top: 0px;
+  left: 25px;
+}
+</style>

--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -8,7 +8,7 @@
     @click="toChats"
   >
     <div class="position-relative">
-      <v-icon name="comments" scale="2" />
+      <v-icon name="comments" scale="2" class="chat__icon" />
       <div v-if="!smallScreen" class="nav-item__text">
         Chats
       </div>
@@ -69,7 +69,7 @@ export default {
   left: 25px;
 }
 
-svg.fa-icon {
+.chat__icon {
   height: 32px;
   margin: 0;
 }

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -100,8 +100,6 @@ export default {
       if (this.complete) {
         $state.complete()
       } else {
-        this.busy = true
-
         try {
           const currentCount = this.notifications.length
 
@@ -117,10 +115,8 @@ export default {
           } else {
             $state.loaded()
           }
-          this.busy = false
         } catch (e) {
           console.error(e)
-          this.busy = false
           $state.complete()
         }
       }

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -45,6 +45,7 @@ const Notification = () => import('~/components/Notification')
 const InfiniteLoading = () => import('vue-infinite-loading')
 
 export default {
+  name: 'NotificationOptions',
   components: {
     InfiniteLoading,
     Notification

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -1,0 +1,182 @@
+<template>
+  <component
+    :is="notificationType"
+    class="white text-center notification-list"
+    :class="{'mr-2' : smallScreen}"
+    :variant="smallScreen ? 'transparent' : ''"
+    toggle-class="notification-list__dropdown-toggle"
+    menu-class="notification-list__dropdown-menu"
+    lazy
+    right
+    @shown="loadLatestNotifications"
+  >
+    <template slot="button-content">
+      <div class="position-relative" :class="{'text-center small' : !smallScreen}">
+        <v-icon name="bell" scale="2" class="notification-list__icon" />
+        <b-badge v-if="unreadNotificationCount" variant="danger" class="notification-badge">
+          {{ unreadNotificationCount }}
+        </b-badge>
+        <div v-if="!smallScreen" class="nav-item__text">
+          Notifications
+        </div>
+      </div>
+    </template>
+    <b-dropdown-item class="text-right" link-class="notification-list__item">
+      <b-btn variant="white" size="sm" @click="markAllRead">
+        Mark all read
+      </b-btn>
+    </b-dropdown-item>
+    <b-dropdown-divider />
+    <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad" link-class="notification-list__item">
+      <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
+    </b-dropdown-item>
+    <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
+      <span slot="no-results" />
+      <span slot="no-more" />
+      <span slot="spinner">
+        <b-img-lazy src="~/static/loader.gif" alt="Loading" />
+      </span>
+    </infinite-loading>
+  </component>
+</template>
+
+<script>
+const Notification = () => import('~/components/Notification')
+const InfiniteLoading = () => import('vue-infinite-loading')
+
+export default {
+  components: {
+    InfiniteLoading,
+    Notification
+  },
+  props: {
+    distance: {
+      type: Number,
+      required: true
+    },
+    smallScreen: {
+      type: Boolean,
+      required: false
+    }
+  },
+  computed: {
+    notificationType() {
+      return this.smallScreen ? 'b-dropdown' : 'b-nav-item-dropdown'
+    },
+    notifications() {
+      return this.$store.getters[
+        'notifications/getCurrentListInDescendingDateOrder'
+      ]
+    },
+    unreadNotificationCount() {
+      return this.$store.getters['notifications/getUnreadCount']
+    }
+  },
+  watch: {
+    unreadNotificationCount: function() {
+      this.$emit('unread-notification-count', this.unreadNotificationCount)
+    }
+  },
+  mounted() {
+    const me = this.$store.getters['auth/user']
+
+    if (me && me.id) {
+      // Get notifications and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
+      this.$store.dispatch('notifications/updateNotifications')
+    }
+  },
+  methods: {
+    loadLatestNotifications() {
+      // We want to make sure we have the most up to date notifications.
+      this.complete = false
+      this.$store.dispatch('notifications/clear')
+      this.$store.dispatch('notifications/fetchNextListChunk')
+    },
+    loadMoreNotifications: function($state) {
+      const currentCount = this.notifications.length
+
+      if (this.complete) {
+        $state.complete()
+      } else {
+        this.busy = true
+        this.$store
+          .dispatch('notifications/fetchNextListChunk')
+          .then(() => {
+            try {
+              const notifications = this.$store.getters[
+                'notifications/getCurrentList'
+              ]
+
+              if (currentCount === notifications.length) {
+                this.complete = true
+                $state.complete()
+              } else {
+                $state.loaded()
+              }
+              this.busy = false
+            } catch (e) {
+              console.error(e)
+              console.log('Error')
+            }
+          })
+          .catch(e => {
+            console.error(e)
+            this.busy = false
+            $state.complete()
+          })
+      }
+    },
+    async markAllRead() {
+      await this.$store.dispatch('notifications/allSeen')
+      await this.$store.dispatch('notifications/updateUnreadNotificationCount')
+      await this.$store.dispatch('notifications/fetchNextListChunk')
+    },
+    showAboutMe() {
+      this.$emit('showAboutMe')
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import 'color-vars';
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins/_breakpoints';
+
+.notification-badge {
+  position: absolute;
+  top: 0px;
+  left: 18px;
+
+  @include media-breakpoint-up(xl) {
+    left: 40px;
+  }
+}
+
+.notification-list {
+  max-width: 100%;
+}
+
+.notification-list__icon {
+  height: 32px;
+  margin-bottom: 0;
+}
+
+/* These classes style the bootstrap b-nav-item-dropdown component */
+::v-deep .notification-list__dropdown-toggle {
+  color: $color-white !important;
+}
+
+::v-deep .notification-list__dropdown-menu {
+  height: 500px;
+  overflow-y: auto;
+}
+
+.notification-list ::v-deep .dropdown-item {
+  width: 300px;
+  max-width: 100%;
+  padding-left: 5px;
+  overflow-wrap: break-word;
+}
+</style>

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -56,7 +56,8 @@ export default {
     },
     smallScreen: {
       type: Boolean,
-      required: false
+      required: false,
+      default: false
     }
   },
   computed: {

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -8,6 +8,7 @@
     menu-class="notification-list__dropdown-menu"
     lazy
     right
+    aria-label="notifications"
     @shown="loadLatestNotifications"
   >
     <template slot="button-content">

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -64,6 +64,7 @@ export default {
   },
   computed: {
     notificationType() {
+      // A different component needs to be created depending on the context in which it's used
       return this.smallScreen ? 'b-dropdown' : 'b-nav-item-dropdown'
     },
     notifications() {
@@ -84,7 +85,7 @@ export default {
     const me = this.$store.getters['auth/user']
 
     if (me && me.id) {
-      // Get notifications and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
+      // Get notifications and poll regularly for new ones.
       this.$store.dispatch('notifications/updateNotifications')
     }
   },

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -78,7 +78,7 @@ export default {
   },
   watch: {
     unreadNotificationCount: function() {
-      this.$emit('unread-notification-count', this.unreadNotificationCount)
+      this.$emit('update:unreadNotificationCount', this.unreadNotificationCount)
     }
   },
   mounted() {

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -96,38 +96,33 @@ export default {
       this.$store.dispatch('notifications/clear')
       this.$store.dispatch('notifications/fetchNextListChunk')
     },
-    loadMoreNotifications: function($state) {
-      const currentCount = this.notifications.length
-
+    loadMoreNotifications: async function($state) {
       if (this.complete) {
         $state.complete()
       } else {
         this.busy = true
-        this.$store
-          .dispatch('notifications/fetchNextListChunk')
-          .then(() => {
-            try {
-              const notifications = this.$store.getters[
-                'notifications/getCurrentList'
-              ]
 
-              if (currentCount === notifications.length) {
-                this.complete = true
-                $state.complete()
-              } else {
-                $state.loaded()
-              }
-              this.busy = false
-            } catch (e) {
-              console.error(e)
-              console.log('Error')
-            }
-          })
-          .catch(e => {
-            console.error(e)
-            this.busy = false
+        try {
+          const currentCount = this.notifications.length
+
+          await this.$store.dispatch('notifications/fetchNextListChunk')
+
+          const notifications = this.$store.getters[
+            'notifications/getCurrentList'
+          ]
+
+          if (currentCount === notifications.length) {
+            this.complete = true
             $state.complete()
-          })
+          } else {
+            $state.loaded()
+          }
+          this.busy = false
+        } catch (e) {
+          console.error(e)
+          this.busy = false
+          $state.complete()
+        }
       }
     },
     async markAllRead() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,8 +51,8 @@
             </div>
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
-            <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
-            <ChatMenu :small-screen="false" @chat-count="chatCount=$event" />
+            <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
+            <ChatMenu :small-screen="false" :chat-count.sync="chatCount" />
             <b-nav-item v-if="!simple" id="menu-option-spread" class="text-center small p-0" to="/promote" @mousedown="maybeReload('/promote')">
               <div class="notifwrapper">
                 <v-icon name="bullhorn" scale="2" /><br>
@@ -98,8 +98,8 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <NotificationOptions :distance="distance" :small-screen="true" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
-          <ChatMenu v-if="loggedIn" :small-screen="true" @chat-count="chatCount=$event" />
+          <NotificationOptions :distance="distance" :small-screen="true" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
+          <ChatMenu v-if="loggedIn" :small-screen="true" :chat-count.sync="chatCount" />
         </client-only>
 
         <b-navbar-nav>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -52,15 +52,7 @@
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
             <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
-            <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @click="toChats">
-              <div class="notifwrapper">
-                <v-icon name="comments" scale="2" /><br>
-                <span class="nav-item__text">Chats</span>
-                <b-badge v-if="chatCount" variant="danger" class="chatbadge">
-                  {{ chatCount }}
-                </b-badge>
-              </div>
-            </b-nav-item>
+            <ChatMenu :small-screen="false" @chat-count="chatCount=$event" />
             <b-nav-item v-if="!simple" id="menu-option-spread" class="text-center small p-0" to="/promote" @mousedown="maybeReload('/promote')">
               <div class="notifwrapper">
                 <v-icon name="bullhorn" scale="2" /><br>
@@ -107,12 +99,7 @@
       <div class="d-flex align-items-center">
         <client-only>
           <NotificationOptions :distance="distance" :small-screen="true" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
-          <a v-if="loggedIn" id="menu-option-chat-sm" href="#" class="text-white mr-3 position-relative" @click="toChats">
-            <v-icon name="comments" scale="2" /><br>
-            <b-badge v-if="chatCount" variant="danger" class="chatbadge">
-              {{ chatCount }}
-            </b-badge>
-          </a>
+          <ChatMenu v-if="loggedIn" :small-screen="true" @chat-count="chatCount=$event" />
         </client-only>
 
         <b-navbar-nav>
@@ -206,6 +193,7 @@ import LoginModal from '~/components/LoginModal'
 import LocalStorageMonitor from '~/components/LocalStorageMonitor'
 import BouncingEmail from '~/components/BouncingEmail'
 import NotificationOptions from '~/components/NotificationOptions'
+import ChatMenu from '~/components/ChatMenu'
 
 const AboutMeModal = () => import('~/components/AboutMeModal')
 const ChatPopups = () => import('~/components/ChatPopups')
@@ -221,7 +209,8 @@ export default {
     LocalStorageMonitor,
     BouncingEmail,
     ExternalLink,
-    NotificationOptions
+    NotificationOptions,
+    ChatMenu
   },
 
   data: function() {
@@ -232,7 +221,8 @@ export default {
       nchan: null,
       logo: require(`@/static/icon.png`),
       timeTimer: null,
-      unreadNotificationCount: 0
+      unreadNotificationCount: 0,
+      chatCount: 0
     }
   },
 
@@ -247,13 +237,6 @@ export default {
           href: '/icon.png'
         }
       ]
-    }
-  },
-
-  computed: {
-    chatCount() {
-      // Don't show so many that the layout breaks.
-      return Math.min(99, this.$store.getters['chats/unseenCount'])
     }
   },
 
@@ -526,21 +509,6 @@ export default {
       }
     },
 
-    toChats(e) {
-      if (e) {
-        e.preventDefault()
-        e.stopPropagation()
-        e.stopImmediatePropagation()
-      }
-
-      // Ensure we have no chat selected.  On mobile this will force us to show the chat list.
-      this.$store.dispatch('chats/currentChat', {
-        chatid: null
-      })
-
-      this.$router.push('/chats')
-    },
-
     updateTime() {
       this.$store.dispatch('misc/setTime')
       this.timeTimer = setTimeout(this.updateTime, 10000)
@@ -697,12 +665,6 @@ svg.fa-icon {
 
 .notifwrapper {
   position: relative;
-}
-
-.chatbadge {
-  position: absolute;
-  top: 0px;
-  left: 25px;
 }
 
 #serverloader {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,33 +51,7 @@
             </div>
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
-            <b-nav-item-dropdown v-if="!simple" class="white text-center notiflist" lazy right @shown="loadLatestNotifications">
-              <template slot="button-content">
-                <div class="notifwrapper text-center small">
-                  <v-icon name="bell" scale="2" />
-                  <b-badge v-if="notificationCount" variant="danger" class="notification-badge">
-                    {{ notificationCount }}
-                  </b-badge><br>
-                  <span class="nav-item__text">Notifications</span>
-                </div>
-              </template>
-              <b-dropdown-item class="text-right">
-                <b-btn variant="white" size="sm" @click="markAllRead">
-                  Mark all read
-                </b-btn>
-              </b-dropdown-item>
-              <b-dropdown-divider />
-              <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad">
-                <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
-              </b-dropdown-item>
-              <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
-                <span slot="no-results" />
-                <span slot="no-more" />
-                <span slot="spinner">
-                  <b-img-lazy src="~/static/loader.gif" alt="Loading" />
-                </span>
-              </infinite-loading>
-            </b-nav-item-dropdown>
+            <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
             <b-nav-item id="menu-option-chat" class="text-center small p-0" to="/chats" @click="toChats">
               <div class="notifwrapper">
                 <v-icon name="comments" scale="2" /><br>
@@ -132,40 +106,7 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <b-dropdown
-            v-if="loggedIn"
-            class="white text-center notiflist mr-2"
-            variant="transparent"
-            lazy
-            right
-            @shown="loadLatestNotifications"
-          >
-            <template slot="button-content">
-              <div class="notifwrapper">
-                <v-icon name="bell" scale="2" class="" />
-                <b-badge v-if="notificationCount" variant="danger" class="notification-badge">
-                  {{ notificationCount }}
-                </b-badge>
-              </div>
-            </template>
-            <b-dropdown-item class="text-right">
-              <b-btn variant="white" size="sm" @click="markAllRead">
-                Mark all read
-              </b-btn>
-            </b-dropdown-item>
-            <b-dropdown-divider />
-            <b-dropdown-item v-for="notification in notifications" :key="'notification-' + notification.id" class="p-0 notpad">
-              <Notification :notification="notification" class="p-0" @showModal="showAboutMe" />
-            </b-dropdown-item>
-            <infinite-loading :distance="distance" @infinite="loadMoreNotifications">
-              <span slot="no-results" />
-              <span slot="no-more" />
-              <span slot="spinner">
-                <b-img-lazy src="~/static/loader.gif" alt="Loading" />
-              </span>
-            </infinite-loading>
-          </b-dropdown>
-
+          <NotificationOptions :distance="distance" :small-screen="true" @unread-notification-count="unreadNotificationCount=$event" @showAboutMe="showAboutMe" />
           <a v-if="loggedIn" id="menu-option-chat-sm" href="#" class="text-white mr-3 position-relative" @click="toChats">
             <v-icon name="comments" scale="2" /><br>
             <b-badge v-if="chatCount" variant="danger" class="chatbadge">
@@ -264,25 +205,23 @@ import SimpleView from '../components/SimpleView'
 import LoginModal from '~/components/LoginModal'
 import LocalStorageMonitor from '~/components/LocalStorageMonitor'
 import BouncingEmail from '~/components/BouncingEmail'
+import NotificationOptions from '~/components/NotificationOptions'
 
 const AboutMeModal = () => import('~/components/AboutMeModal')
 const ChatPopups = () => import('~/components/ChatPopups')
-const Notification = () => import('~/components/Notification')
 const NchanSubscriber = require('nchan')
-const InfiniteLoading = () => import('vue-infinite-loading')
 const ExternalLink = () => import('~/components/ExternalLink')
 
 export default {
   components: {
     SimpleView,
-    InfiniteLoading,
     ChatPopups,
-    Notification,
     AboutMeModal,
     LoginModal,
     LocalStorageMonitor,
     BouncingEmail,
-    ExternalLink
+    ExternalLink,
+    NotificationOptions
   },
 
   data: function() {
@@ -311,14 +250,6 @@ export default {
   },
 
   computed: {
-    notifications() {
-      return this.$store.getters[
-        'notifications/getCurrentListInDescendingDateOrder'
-      ]
-    },
-    notificationCount() {
-      return this.$store.getters['notifications/getUnreadCount']
-    },
     chatCount() {
       // Don't show so many that the layout breaks.
       return Math.min(99, this.$store.getters['chats/unseenCount'])
@@ -392,9 +323,8 @@ export default {
       console.log('Start NCHAN from mount')
       this.startNCHAN(me.id)
 
-      // Get notifications and chats and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
+      // Get chats and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
       this.fetchLatestChats()
-      this.$store.dispatch('notifications/updateNotifications')
     }
 
     // Look for a custom logo.
@@ -584,48 +514,6 @@ export default {
       this.$router.push('/')
     },
 
-    loadMoreNotifications: function($state) {
-      const currentCount = this.notifications.length
-
-      if (this.complete) {
-        $state.complete()
-      } else {
-        this.busy = true
-        this.$store
-          .dispatch('notifications/fetchNextListChunk')
-          .then(() => {
-            try {
-              const notifications = this.$store.getters[
-                'notifications/getCurrentList'
-              ]
-
-              if (currentCount === notifications.length) {
-                this.complete = true
-                $state.complete()
-              } else {
-                $state.loaded()
-              }
-              this.busy = false
-            } catch (e) {
-              console.error(e)
-              console.log('Error')
-            }
-          })
-          .catch(e => {
-            console.error(e)
-            this.busy = false
-            $state.complete()
-          })
-      }
-    },
-
-    loadLatestNotifications() {
-      // We want to make sure we have the most up to date notifications.
-      this.complete = false
-      this.$store.dispatch('notifications/clear')
-      this.$store.dispatch('notifications/fetchNextListChunk')
-    },
-
     requestLogin() {
       this.$refs.loginModal.show()
     },
@@ -650,12 +538,6 @@ export default {
       })
 
       this.$router.push('/chats')
-    },
-
-    async markAllRead() {
-      await this.$store.dispatch('notifications/allSeen')
-      await this.$store.dispatch('notifications/updateUnreadNotificationCount')
-      await this.$store.dispatch('notifications/fetchNextListChunk')
     },
 
     updateTime() {
@@ -816,16 +698,6 @@ svg.fa-icon {
   position: relative;
 }
 
-.notification-badge {
-  position: absolute;
-  top: 0px;
-  left: 18px;
-
-  @include media-breakpoint-up(xl) {
-    left: 40px;
-  }
-}
-
 .chatbadge {
   position: absolute;
   top: 0px;
@@ -889,9 +761,5 @@ svg.fa-icon {
 .mainnav--right {
   width: 40%;
   max-width: 400px;
-}
-
-.notiflist ::v-deep .dropdown-toggle {
-  color: $color-white;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -231,12 +231,13 @@ export default {
       chatPoll: null,
       nchan: null,
       logo: require(`@/static/icon.png`),
-      timeTimer: null
+      timeTimer: null,
+      unreadNotificationCount: 0
     }
   },
 
   head() {
-    const totalCount = this.notificationCount + this.chatCount
+    const totalCount = this.unreadNotificationCount + this.chatCount
     return {
       titleTemplate: totalCount > 0 ? `(${totalCount}) %s` : '%s',
       link: [

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -142,7 +142,7 @@ export const actions = {
       }
     }
 
-    // Continuously check for updated notifications
+    // Continuously check for updated notifications. Would be nice if this was event driven instead but requires server work.
     // No need to clear the timeout
     setTimeout(() => {
       dispatch('updateNotifications')


### PR DESCRIPTION
This is a rethink of the notification options component.

Generally I'm happy with the component now although I need to give it some more testing hence the draft PR.  The only point of contention is the about me modal which I've been struggling with a bit.

So at the moment the component can only have a single element due to the way the parent is set up.  The parent in some cases is a UL and so the component can't have a wrapper DIV or it breaks the structure.

Thinking about ownership, it doesn't seem right for the about me modal to live in the notification component.  It has got nothing to do with notifications.  It just happens to be called from that component.  This modal is called from other places and these places currently also define a version of the modal. (Potential future refactor...)

This PR leaves the about me modal in the default layout and just raises an event from the notifications component to show it.  To me this feels much nicer as it keeps the notification component clean and focused on one thing.

Thoughts?
