### PR TITLE
Chat menu refactoring for default and modtools layouts

### DIFF
--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -1,15 +1,14 @@
 <template>
   <component
     :is="chatType"
-    :id="smallScreen ? 'menu-option-chat-sm' : 'menu-option-chat'"
-    :class="smallScreen ? 'text-white mr-3 position-relative' : 'text-center small p-0'"
+    :class="{'text-white' : !isListItem}"
     href="#"
     aria-label="chats"
     @click="toChats"
   >
-    <div class="position-relative">
+    <div class="position-relative small">
       <v-icon name="comments" scale="2" class="chat__icon" />
-      <div v-if="!smallScreen" class="nav-item__text">
+      <div class="nav-item__text d-none d-xl-block">
         Chats
       </div>
       <b-badge v-if="chatCount" variant="danger" class="chatbadge">
@@ -23,16 +22,16 @@
 export default {
   name: 'ChatMenu',
   props: {
-    smallScreen: {
+    isListItem: {
       type: Boolean,
       required: false,
-      default: false
+      default: true
     }
   },
   computed: {
     chatType() {
       // A different component needs to be created depending on the context in which it's used
-      return this.smallScreen ? 'a' : 'b-nav-item'
+      return this.isListItem ? 'b-nav-item' : 'a'
     },
     chatCount() {
       // Don't show so many that the layout breaks.
@@ -57,7 +56,13 @@ export default {
         chatid: null
       })
 
-      this.$router.push('/chats')
+      const modtools = this.$store.getters['misc/get']('modtools')
+
+      if (modtools) {
+        this.$router.push('/modtools/chats')
+      } else {
+        this.$router.push('/chats')
+      }
     }
   }
 }

--- a/components/ChatMenu.vue
+++ b/components/ChatMenu.vue
@@ -2,6 +2,7 @@
   <component
     :is="chatType"
     :class="{'text-white' : !isListItem}"
+    class="chat-menu-item"
     href="#"
     aria-label="chats"
     @click="toChats"
@@ -69,6 +70,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import 'color-vars';
+
 .chatbadge {
   position: absolute;
   top: 0px;
@@ -78,5 +81,16 @@ export default {
 .chat__icon {
   height: 32px;
   margin: 0;
+}
+
+// We need to style the anchor but also override the bootstrap nav-link class
+.chat-menu-item,
+::v-deep .nav-link {
+  color: $color-white !important;
+
+  &:hover,
+  &:focus {
+    color: $color-white-opacity-75 !important;
+  }
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -52,7 +52,7 @@
           </client-only>
           <b-navbar-nav class="mainnav mainnav--right">
             <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
-            <ChatMenu :small-screen="false" :chat-count.sync="chatCount" />
+            <ChatMenu id="menu-option-chat" :is-list-item="true" :chat-count.sync="chatCount" />
             <b-nav-item v-if="!simple" id="menu-option-spread" class="text-center small p-0" to="/promote" @mousedown="maybeReload('/promote')">
               <div class="notifwrapper">
                 <v-icon name="bullhorn" scale="2" /><br>
@@ -99,7 +99,7 @@
       <div class="d-flex align-items-center">
         <client-only>
           <NotificationOptions :distance="distance" :small-screen="true" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
-          <ChatMenu v-if="loggedIn" :small-screen="true" :chat-count.sync="chatCount" />
+          <ChatMenu v-if="loggedIn" id="menu-option-chat-sm" :is-list-item="false" :chat-count.sync="chatCount" class="mr-3" />
         </client-only>
 
         <b-navbar-nav>
@@ -562,22 +562,6 @@ nav .navbar-nav li a.nuxt-link-active {
   &:hover,
   &:focus {
     color: $color-white-opacity-75 !important;
-  }
-}
-
-#menu-option-chat-sm {
-  &:hover,
-  &:focus {
-    color: $color-white-opacity-75 !important;
-  }
-
-  &.nuxt-link-active {
-    color: $color-white-opacity-50 !important;
-
-    &:hover,
-    &:focus {
-      color: $color-white-opacity-75 !important;
-    }
   }
 }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -54,7 +54,7 @@
             <NotificationOptions v-if="!simple" :distance="distance" :small-screen="false" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
             <ChatMenu id="menu-option-chat" :is-list-item="true" :chat-count.sync="chatCount" />
             <b-nav-item v-if="!simple" id="menu-option-spread" class="text-center small p-0" to="/promote" @mousedown="maybeReload('/promote')">
-              <div class="notifwrapper">
+              <div class="position-relative">
                 <v-icon name="bullhorn" scale="2" /><br>
                 <span class="nav-item__text">Promote</span>
               </div>
@@ -625,10 +625,6 @@ body.modal-open {
 
 svg.fa-icon {
   height: 32px;
-}
-
-.notifwrapper {
-  position: relative;
 }
 
 #serverloader {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -217,7 +217,6 @@ export default {
     return {
       complete: false,
       distance: 1000,
-      chatPoll: null,
       nchan: null,
       logo: require(`@/static/icon.png`),
       timeTimer: null,
@@ -307,8 +306,8 @@ export default {
       console.log('Start NCHAN from mount')
       this.startNCHAN(me.id)
 
-      // Get chats and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
-      this.fetchLatestChats()
+      // Get chats and poll regularly for new ones
+      this.$store.dispatch('chats/fetchLatestChats')
     }
 
     // Look for a custom logo.
@@ -383,7 +382,6 @@ export default {
 
   beforeDestroy() {
     console.log('Destroy layout')
-    clearTimeout(this.chatPoll)
     clearTimeout(this.timeTimer)
 
     if (this.nchan && this.nchan.running) {
@@ -460,24 +458,6 @@ export default {
           }
         }
       })
-    },
-    async fetchLatestChats() {
-      const me = this.$store.getters['auth/user']
-
-      if (me && me.id) {
-        const currentCount = this.$store.getters['chats/unseenCount']
-        const newCount = await this.$store.dispatch('chats/unseenCount')
-
-        if (newCount !== currentCount) {
-          await this.$store.dispatch('chats/listChats', {
-            chattypes: ['User2User', 'User2Mod'],
-            summary: true,
-            noerror: true
-          })
-        }
-      }
-
-      this.chatPoll = setTimeout(this.fetchLatestChats, 30000)
     },
 
     showAboutMe() {

--- a/layouts/modtools.vue
+++ b/layouts/modtools.vue
@@ -199,6 +199,9 @@ export default {
       all: true
     })
 
+    // Get chats and poll regularly for new ones
+    this.$store.dispatch('chats/fetchLatestChats')
+
     setTimeout(this.updateFavicon, 1000)
   },
   beforeDestroy() {
@@ -247,17 +250,6 @@ export default {
         components: ['work'],
         force: true
       })
-
-      const currentCount = this.$store.getters['chats/unseenCount']
-      const newCount = await this.$store.dispatch('chats/unseenCount')
-
-      if (newCount !== currentCount) {
-        await this.$store.dispatch('chats/listChats', {
-          chattypes: ['User2User', 'User2Mod'],
-          summary: true,
-          noerror: true
-        })
-      }
 
       setTimeout(this.checkWork, 30000)
     },

--- a/layouts/modtools.vue
+++ b/layouts/modtools.vue
@@ -1,7 +1,7 @@
 <template>
   <client-only>
     <div class="pageback">
-      <b-navbar id="navbar" type="dark" class="navback p-0 p-sm-1" fixed="top">
+      <b-navbar id="navbar" type="dark" class="navback p-0 p-sm-1 justify-content-between" fixed="top">
         <b-navbar-brand class="p-0 pr-2 d-flex">
           <b-img
             class="logo clickme"
@@ -13,39 +13,28 @@
           />
           <ModStatus class="status" />
         </b-navbar-brand>
-        <b-navbar-nav class="d-flex w-100 justify-content-end">
-          <b-nav-item v-if="loggedIn" id="menu-option-modtools-discourse2" class="text-center p-0" @click="discourse">
+        <b-navbar-nav class="d-flex align-items-center">
+          <b-nav-item v-if="loggedIn" id="menu-option-modtools-discourse2" class="text-center small p-0 mr-4" @click="discourse">
             <div>
-              <span class="d-none d-sm-inline">
+              <div class="d-none d-sm-inline">
                 <v-icon name="brands/discourse" scale="2" class="fw" /><br>
-                Us
-              </span>
+                <div class="d-none d-xl-block">
+                  Us
+                </div>
+              </div>
               <div class="position-relative d-inline">
-                <v-icon name="brands/discourse" class="d-inline d-sm-none ml-2 mr-2 mt-2" scale="2.5" />
+                <v-icon name="brands/discourse" class="d-inline d-sm-none" scale="2" />
                 <b-badge v-show="discourseCount" variant="success">
                   {{ discourseCount }}
                 </b-badge>
               </div>
             </div>
           </b-nav-item>
-          <b-nav-item v-if="loggedIn" id="menu-option-modtools-chat2" class="text-center p-0" @click="toChats">
-            <div>
-              <span class="d-none d-sm-inline">
-                <v-icon name="comments" scale="2" class="fw" /><br>
-                Chats
-              </span>
-              <div class="position-relative d-inline">
-                <v-icon name="comments" class="d-inline d-sm-none ml-2 mr-4 mt-2" scale="2.5" />
-                <b-badge v-show="chatCount" variant="danger" class="badge">
-                  {{ chatCount }}
-                </b-badge>
-              </div>
-            </div>
-          </b-nav-item>
+          <ChatMenu v-if="loggedIn" id="menu-option-modtools-chat2" :is-list-item="true" :chat-count.sync="chatCount" class="mr-4" />
           <b-nav-item v-if="loggedIn">
             <div class="position-relative">
               <b-btn variant="white" class="menu" @click="toggleMenu">
-                <v-icon name="bars" class="mb-1" scale="2.2" />
+                <v-icon name="bars" class="" scale="1.5" />
               </b-btn>
               <b-badge v-show="menuCount" v-if="!showMenu" variant="danger" class="menuCount position-absolute">
                 {{ menuCount }}
@@ -121,6 +110,7 @@ import ModMenuItemLeft from '../components/ModMenuItemLeft'
 import waitForRef from '../mixins/waitForRef'
 import LoginModal from '~/components/LoginModal'
 import ModStatus from '~/components/ModStatus'
+import ChatMenu from '~/components/ChatMenu'
 const ExternalLink = () => import('~/components/ExternalLink')
 
 const ChatPopups = () => import('~/components/ChatPopups')
@@ -131,6 +121,7 @@ export default {
     ChatPopups,
     LoginModal,
     ModStatus,
+    ChatMenu,
     ExternalLink
   },
   mixins: [waitForRef],
@@ -139,14 +130,11 @@ export default {
       logo: require(`@/static/icon_modtools.png`),
       showMenu: false,
       sliding: false,
-      timeTimer: null
+      timeTimer: null,
+      chatCount: 0
     }
   },
   computed: {
-    chatCount() {
-      // Don't show so many that the layout breaks.
-      return Math.min(99, this.$store.getters['chats/unseenCount'])
-    },
     discourseCount() {
       const discourse = this.$store.getters['auth/discourse']
       return discourse
@@ -354,7 +342,6 @@ html {
 
 @include media-breakpoint-up(sm) {
   #navbar .nav-item {
-    width: 80px;
     text-align: center;
   }
 }

--- a/layouts/modtools.vue
+++ b/layouts/modtools.vue
@@ -275,20 +275,6 @@ export default {
     toggleMenu() {
       this.showMenu = !this.showMenu
     },
-    toChats(e) {
-      if (e) {
-        e.preventDefault()
-        e.stopPropagation()
-        e.stopImmediatePropagation()
-      }
-
-      // Ensure we have no chat selected.  On mobile this will force us to show the chat list.
-      this.$store.dispatch('chats/currentChat', {
-        chatid: null
-      })
-
-      this.$router.push('/modtools/chats')
-    },
     updateTime() {
       this.$store.dispatch('misc/setTime')
       this.timeTimer = setTimeout(this.updateTime, 30000)

--- a/store/chats.js
+++ b/store/chats.js
@@ -238,7 +238,10 @@ export const actions = {
   },
 
   async fetchLatestChats({ dispatch, rootGetters }, params) {
+    const chatTypes = ['User2User', 'User2Mod']
+    const modOnlyChatTypes = ['Mod2Mod']
     const me = rootGetters['auth/user']
+    const modtools = rootGetters['misc/get']('modtools')
 
     if (me && me.id) {
       const currentCount = rootGetters['chats/unseenCount']
@@ -246,7 +249,7 @@ export const actions = {
 
       if (newCount !== currentCount) {
         await dispatch('listChats', {
-          chattypes: ['User2User', 'User2Mod'],
+          chattypes: modtools ? [...chatTypes, ...modOnlyChatTypes] : chatTypes,
           summary: true,
           noerror: true
         })

--- a/store/chats.js
+++ b/store/chats.js
@@ -235,5 +235,28 @@ export const actions = {
 
   currentChat({ commit }, params) {
     commit('currentChat', params.chatid)
+  },
+
+  async fetchLatestChats({ dispatch, rootGetters }, params) {
+    const me = rootGetters['auth/user']
+
+    if (me && me.id) {
+      const currentCount = rootGetters['chats/unseenCount']
+      const newCount = await dispatch('unseenCount')
+
+      if (newCount !== currentCount) {
+        await dispatch('listChats', {
+          chattypes: ['User2User', 'User2Mod'],
+          summary: true,
+          noerror: true
+        })
+      }
+    }
+
+    // Continuously check for updated chats. Would be nice if this was event driven instead but requires server work.
+    // No need to clear the timeout
+    setTimeout(() => {
+      dispatch('fetchLatestChats')
+    }, 30000)
   }
 }


### PR DESCRIPTION
- Tweaks to the chatmenu component so it's more generic
- Move chat fetching into the store rather than the layout components
- Use the chatmenu component from MT