### PR TITLE
Refactor the nchan logic into a mixin

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -194,10 +194,10 @@ import LocalStorageMonitor from '~/components/LocalStorageMonitor'
 import BouncingEmail from '~/components/BouncingEmail'
 import NotificationOptions from '~/components/NotificationOptions'
 import ChatMenu from '~/components/ChatMenu'
+import nchanHelper from '@/mixins/nchanHelper'
 
 const AboutMeModal = () => import('~/components/AboutMeModal')
 const ChatPopups = () => import('~/components/ChatPopups')
-const NchanSubscriber = require('nchan')
 const ExternalLink = () => import('~/components/ExternalLink')
 
 export default {
@@ -212,13 +212,12 @@ export default {
     NotificationOptions,
     ChatMenu
   },
-
+  mixins: [nchanHelper],
   data: function() {
     return {
       complete: false,
       distance: 1000,
       chatPoll: null,
-      nchan: null,
       logo: require(`@/static/icon.png`),
       timeTimer: null,
       unreadNotificationCount: 0,
@@ -256,22 +255,6 @@ export default {
       ) {
         this.$root.$emit('bv::toggle::collapse', 'nav_collapse_mobile')
       }
-    },
-    me(newVal, oldVal) {
-      if (this.nchan && this.nchan.running) {
-        // Stop old listen.
-        try {
-          this.nchan.stop()
-        } catch (e) {}
-      }
-
-      this.nchan = null
-
-      if (newVal) {
-        // We are now logged in.
-        console.log('Start NCHAN from watch')
-        this.startNCHAN(newVal.id)
-      }
     }
   },
 
@@ -304,9 +287,6 @@ export default {
     const me = this.$store.getters['auth/user']
 
     if (me && me.id) {
-      console.log('Start NCHAN from mount')
-      this.startNCHAN(me.id)
-
       // Get chats and poll regularly for new ones.  Would be nice if this was event driven instead but requires server work.
       this.fetchLatestChats()
     }
@@ -385,82 +365,9 @@ export default {
     console.log('Destroy layout')
     clearTimeout(this.chatPoll)
     clearTimeout(this.timeTimer)
-
-    if (this.nchan && this.nchan.running) {
-      console.log('Stop NCHAN')
-      try {
-        this.nchan.stop()
-      } catch (e) {}
-    }
-
-    this.nchan = null
   },
 
   methods: {
-    startNCHAN(id) {
-      this.nchan = new NchanSubscriber(
-        process.env.CHAT_HOST + '/subscribe?id=' + id,
-        {
-          subscriber: ['longpoll']
-        }
-      )
-
-      // We store the last message we got from NCHAN.  This avoids us getting duplicate messages (triggering server
-      // work) when we load up.
-      const lastNCHAN = this.$store.getters['auth/nchan']
-
-      if (lastNCHAN) {
-        this.nchan.lastMessageId = lastNCHAN.id
-      }
-
-      // Disabled for now until things settle down.
-      console.log('Not starting NCHAN')
-      // this.nchan.start()
-
-      this.nchan.on('error', function(code, descr) {
-        console.error('NCHAN error', code, descr)
-      })
-
-      this.nchan.on('message', async (ret, meta) => {
-        console.log('NCHAN', ret, meta)
-
-        if (meta.id) {
-          this.$store.dispatch('auth/setNCHAN', {
-            id: meta.id
-          })
-        }
-
-        if (ret) {
-          ret = JSON.parse(ret)
-
-          // We will get notified for both MT and FD chats.  But we only want to react to
-          // the one which this client actually is.
-          const mt =
-            ret && Object.keys(ret).includes('modtools') ? ret.modtools : false
-
-          if (!mt && ret && ret.text) {
-            const data = ret.text
-
-            if (data) {
-              if (data.newroom) {
-                // We have been notified that we are now in a new chat.  Load it into the store; once we've
-                // done that then anything else needed will follow.
-                console.log('Load new room', data.newroom)
-                await this.$store.dispatch('chats/fetch', {
-                  id: data.newroom
-                })
-              } else if (data.roomid) {
-                // Activity on this room.  Fetch it.
-                console.log('Activity on room', data.roomid)
-                await this.$store.dispatch('chats/fetch', {
-                  id: data.roomid
-                })
-              }
-            }
-          }
-        }
-      })
-    },
     async fetchLatestChats() {
       const me = this.$store.getters['auth/user']
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -593,4 +593,3 @@ svg.fa-icon {
   max-width: 400px;
 }
 </style>
-

--- a/mixins/nchanHelper.js
+++ b/mixins/nchanHelper.js
@@ -7,7 +7,7 @@ export default {
     }
   },
   watch: {
-    me(newVal, oldVal) {
+    localMe(newVal, oldVal) {
       if (this.nchan && this.nchan.running) {
         // Stop old listen.
         try {
@@ -25,6 +25,7 @@ export default {
     }
   },
   mounted() {
+    // Get me directly as the computed property might not be available
     const me = this.$store.getters['auth/user']
 
     if (me && me.id) {
@@ -43,7 +44,8 @@ export default {
     this.nchan = null
   },
   computed: {
-    me() {
+    // There should also be a global me property but define a local one to make sure it is present
+    localMe() {
       return this.$store.getters['auth/user']
     }
   },

--- a/mixins/nchanHelper.js
+++ b/mixins/nchanHelper.js
@@ -1,0 +1,116 @@
+const NchanSubscriber = require('nchan')
+
+export default {
+  data: function() {
+    return {
+      nchan: null
+    }
+  },
+  watch: {
+    me(newVal, oldVal) {
+      if (this.nchan && this.nchan.running) {
+        // Stop old listen.
+        try {
+          this.nchan.stop()
+        } catch (e) {}
+      }
+
+      this.nchan = null
+
+      if (newVal) {
+        // We are now logged in.
+        console.log('Start NCHAN from watch')
+        this.startNCHAN(newVal.id)
+      }
+    }
+  },
+  mounted() {
+    const me = this.$store.getters['auth/user']
+
+    if (me && me.id) {
+      console.log('Start NCHAN from mount')
+      this.startNCHAN(me.id)
+    }
+  },
+  beforeDestroy() {
+    if (this.nchan && this.nchan.running) {
+      console.log('Stop NCHAN')
+      try {
+        this.nchan.stop()
+      } catch (e) {}
+    }
+
+    this.nchan = null
+  },
+  computed: {
+    me() {
+      return this.$store.getters['auth/user']
+    }
+  },
+  methods: {
+    startNCHAN(id) {
+      this.nchan = new NchanSubscriber(
+        process.env.CHAT_HOST + '/subscribe?id=' + id,
+        {
+          subscriber: ['longpoll']
+        }
+      )
+
+      // We store the last message we got from NCHAN.  This avoids us getting duplicate messages (triggering server
+      // work) when we load up.
+      const lastNCHAN = this.$store.getters['auth/nchan']
+
+      if (lastNCHAN) {
+        this.nchan.lastMessageId = lastNCHAN.id
+      }
+
+      // Disabled for now until things settle down.
+      console.log('Not starting NCHAN')
+      // this.nchan.start()
+
+      this.nchan.on('error', function(code, descr) {
+        console.error('NCHAN error', code, descr)
+      })
+
+      this.nchan.on('message', async (ret, meta) => {
+        console.log('NCHAN', ret, meta)
+
+        if (meta.id) {
+          this.$store.dispatch('auth/setNCHAN', {
+            id: meta.id
+          })
+        }
+
+        if (ret) {
+          ret = JSON.parse(ret)
+
+          // We will get notified for both MT and FD chats.  But we only want to react to
+          // the one which this client actually is.
+          const mt =
+            ret && Object.keys(ret).includes('modtools') ? ret.modtools : false
+
+          if (!mt && ret && ret.text) {
+            const data = ret.text
+
+            if (data) {
+              if (data.newroom) {
+                // We have been notified that we are now in a new chat.  Load it into the store; once we've
+                // done that then anything else needed will follow.
+                console.log('Load new room', data.newroom)
+                await this.$store.dispatch('chats/fetch', {
+                  id: data.newroom
+                })
+              } else if (data.roomid) {
+                // Activity on this room.  Fetch it.
+                console.log('Activity on room', data.roomid)
+                await this.$store.dispatch('chats/fetch', {
+                  id: data.roomid
+                })
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+}


### PR DESCRIPTION
Here it is... initially just for discussion

My main worries are around "me".  The "me" used in mounted needs to be re-defined as it won't pick up the "me" from the global mixin.  The other oddity is there is a watch over "me" as well.  This appears to work using the one from the me.js mixin but I'm a bit uncomfortable watching something that you are just assuming exists elsewhere.  Therefore I have added a local "me" property.


