### PR TITLE
Use a better method for removing the dropdown caret

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -168,19 +168,6 @@ body.modtools {
     opacity: 0;
 }
 
-.navbar .dropdown-toggle:after {
-  content: none;
-}
-
-nav .dropdown-toggle {
-  border: none;
-
-  &:hover,
-  &:focus {
-    color: $color-white-opacity-75 !important;
-  }
-}
-
 .forcebreak {
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/components/NotificationOptions.vue
+++ b/components/NotificationOptions.vue
@@ -8,6 +8,7 @@
     menu-class="notification-list__dropdown-menu"
     lazy
     right
+    no-caret
     aria-label="notifications"
     @shown="loadLatestNotifications"
   >


### PR DESCRIPTION
There was code to remove the caret from the dropdown but bootstrap provide a way of doing this themselves. 