### PR TITLE
Make the jobs more semantic - put them in a list

### DIFF
--- a/assets/css/typography.scss
+++ b/assets/css/typography.scss
@@ -34,10 +34,6 @@ h1, h2, h3, h4 {
   font-size: 1.25rem;
 }
 
-.header--size6 {
-  font-size: 1rem;
-}
-
 .text-success {
   color: $colour-success !important;
 }

--- a/components/Job.vue
+++ b/components/Job.vue
@@ -1,10 +1,8 @@
 <template>
   <div @click="clicked">
     <div v-if="summary" class="ml-2 mr-2">
-      <h3 class="header--size6">
-        <!-- eslint-disable-next-line -->
-        <span v-html="joblinksumm" />
-      </h3>
+      <!-- eslint-disable-next-line -->
+      <span v-html="joblinksumm" class="job__summary" />
       <p class="text-truncate mt-2 d-none d-lg-block">
         {{ job.snippet }}
       </p>
@@ -116,3 +114,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.job__summary {
+  font-weight: 500;
+}
+</style>

--- a/components/JobsSidebar.vue
+++ b/components/JobsSidebar.vue
@@ -21,9 +21,11 @@
         <p class="text-center small">
           Jobs near you.  Freegle gets a small amount if you click.
         </p>
-        <div v-for="job in visibleJobs" :key="'job-' + job.onmousedown" class="">
-          <Job :summary="true" :job="job" />
-        </div>
+        <ul class="list-unstyled">
+          <li v-for="job in visibleJobs" :key="'job-' + job.onmousedown" class="">
+            <Job :summary="true" :job="job" />
+          </li>
+        </ul>
         <client-only>
           <infinite-loading key="infinitejobs" @infinite="loadMore">
             <span slot="no-results">

--- a/components/JobsTopBar.vue
+++ b/components/JobsTopBar.vue
@@ -22,9 +22,11 @@
           <!-- eslint-disable-next-line -->
         See more<span class="d-none d-md-inline"> jobs</span></nuxt-link>.
       </div>
-      <div v-for="(job, index) in jobs" :key="'job-' + job.onmousedown" class="">
-        <Job :summary="true" :job="job" :class="index > 1 ? 'd-none d-md-block' : ''" />
-      </div>
+      <ul class="list-unstyled">
+        <li v-for="(job, index) in jobs" :key="'job-' + job.onmousedown">
+          <Job :summary="true" :job="job" :class="index > 1 ? 'd-none d-md-block' : ''" />
+        </li>
+      </ul>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This is part of the overall work to tidy up the headers typography.  I'm currently trying to consolidate them down as we currently have about 6 different sizes with very little difference between some of them.

The jobs shouldn't really be headers.  They are just anchors in a list.  So I've put them in a list. 