### PR TITLE
Remove text-small as it's only used in one place

### DIFF
--- a/assets/css/typography.scss
+++ b/assets/css/typography.scss
@@ -43,10 +43,6 @@ h1, h2, h3, h4 {
 }
 
 .text--small {
-  font-size: 0.75rem;
-}
-
-.text--small-medium {
   font-size: 0.9rem;
   line-height: 1.2;
 }

--- a/components/NewsReply.vue
+++ b/components/NewsReply.vue
@@ -15,12 +15,12 @@
               </td>
               <td class="align-top">
                 <span class="text-success font-weight-bold clickme" title="Click to see their profile" @click="showInfo">{{ users[userid].displayname }}</span>
-                <span class="font-weight-bold preline forcebreak text--small-medium nopara">
+                <span class="font-weight-bold preline forcebreak text--small nopara">
                   <NewsHighlight
                     :search-words="threadUsers"
                     :text="emessage"
                     :max-chars="500"
-                    class="font-weight-bold preline forcebreak text--small-medium d-inline"
+                    class="font-weight-bold preline forcebreak text--small d-inline"
                   /> <br>
                 </span>
                 <div v-if="reply.image">


### PR DESCRIPTION
Make the MT history section use a bigger font and then rename the typography definitions to tidy them up.