### PR TITLE
Only show notifications when logged in

### DIFF
--- a/components/MainHeader.vue
+++ b/components/MainHeader.vue
@@ -98,7 +98,7 @@
       </b-navbar-brand>
       <div class="d-flex align-items-center">
         <client-only>
-          <NotificationOptions :distance="distance" :small-screen="true" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
+          <NotificationOptions v-if="loggedIn" :distance="distance" :small-screen="true" :unread-notification-count.sync="unreadNotificationCount" @showAboutMe="showAboutMe" />
           <ChatMenu v-if="loggedIn" id="menu-option-chat-sm" :is-list-item="false" :chat-count.sync="chatCount" class="mr-3" />
         </client-only>
 


### PR DESCRIPTION
Hide the notifications icon on smaller screens when not logged in.