### PR TITLE
Feature/upgrade vue awesome

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -158,7 +158,7 @@ body.modtools {
 
   /* This is to resolve an issue with icon alignment. */
   /* It reverts a change made in 4.1.0 of vue-awesome */
-  vertical-align: middle;
+  vertical-align: middle !important;
 }
 
 .fa-fw {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15476,18 +15476,11 @@
       "integrity": "sha512-WXjngEaNyNWFU9unUUdK5kGolCHgG3jmlUIgeRnKlHpskbgGjIE/HGTOWnMfLEqjYJl9DTzt/SKPWDoFVaND/A=="
     },
     "vue-awesome": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vue-awesome/-/vue-awesome-4.0.2.tgz",
-      "integrity": "sha512-TE9hVwyVrGnBetO/MJwZ/7qLO6Vgr/WrDtIA7vwNryoLdA2jfRcKRw29KacpU5xj3wzZhHfYJ2xJLxfirhmH5Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vue-awesome/-/vue-awesome-4.1.0.tgz",
+      "integrity": "sha512-4n+hg8KIMrwjXV6sRHcRZd18Somih5j4Yk2ZOv95pnvDpzbBkIYW4ktfivhqgNt50m0zDjmeEWiy1iVLtcccfw==",
       "requires": {
-        "nanoid": "^2.1.6"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-        }
+        "core-js": "^3.4.4"
       }
     },
     "vue-client-only": {
@@ -15496,7 +15489,7 @@
       "integrity": "sha512-arhk1wtWAfLsJyxGMoEYhoBowM87/i6HLSG2LH/03Yog6i2d9JEN1peMP0Ceis+/n9DxdenGYZZTxbPPJyHciA=="
     },
     "vue-draggable-resizable": {
-      "version": "github:Freegle/vue-draggable-resizable#4879847be38653d228dd78f811fc2326a53ed43d",
+      "version": "github:Freegle/vue-draggable-resizable#4c71a6c53eb6b2ee78f97a6a85757e14a1144c09",
       "from": "github:Freegle/vue-draggable-resizable"
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "url": "^0.11.0",
     "vue": "^2.6.10",
     "vue-at": "^2.5.0-beta.2",
-    "vue-awesome": "^4.0.2",
+    "vue-awesome": "^4.1.0",
     "vue-draggable-resizable": "github:Freegle/vue-draggable-resizable",
     "vue-fabric-wrapper": "^0.3.71",
     "vue-filepond": "^5.1.3",


### PR DESCRIPTION
As discussed on slack

Try and encourage Vue to use at least 4.1.0 of vue-awesome and force an override of the vertical-align property.