### PR TITLE
Fix hover on the last seen date

### DIFF
--- a/components/ChatHeader.vue
+++ b/components/ChatHeader.vue
@@ -10,7 +10,7 @@
             <div v-if="otheruser.info.lastaccess" class="d-inline d-md-block">
               <span class="d-none d-md-inline">Last seen</span>
               <span class="d-inline d-md-none">Seen</span>
-              <strong title="datetimeshort(otheruser.info.lastaccess)">{{ timeago(otheruser.info.lastaccess) }}</strong>.
+              <strong title=datetimeshort(otheruser.info.lastaccess)>{{ timeago(otheruser.info.lastaccess) }}</strong>.
             </div>
             <div v-if="replytime" class="d-inline d-md-block">
               <span class="d-none d-md-inline">Typically replies in</span>


### PR DESCRIPTION
This fixes the text that is shown if you hover over the last seen time of a member.

Please note that I haven't actually tested this! I am assuming that removing the quotes will show the actual timestamp on hover. If not, then maybe just remove the title attribute completely.